### PR TITLE
[PATCH] Undefined local variable or method 'log' when RMagick error occurs 

### DIFF
--- a/lib/dragonfly/r_magick_utils.rb
+++ b/lib/dragonfly/r_magick_utils.rb
@@ -2,6 +2,7 @@ require 'tempfile'
 
 module Dragonfly
   module RMagickUtils
+    include Loggable
 
     private
 


### PR DESCRIPTION
Loggable was missing from Dragonfly::RMagickUtils so this patch adds it in. 

Once added, error messages are logged correctly once more.
