### PR TITLE
Untitled

### DIFF
--- a/lib/dragonfly/data_storage/file_data_store.rb
+++ b/lib/dragonfly/data_storage/file_data_store.rb
@@ -67,7 +67,7 @@ module Dragonfly
       end
 
       def relative(absolute_path)
-        absolute_path[/^#{root_path}\/(.*)$/, 1]
+        absolute_path[/^#{root_path}\/?(.*)$/, 1]
       end
 
       def directory_empty?(path)


### PR DESCRIPTION
I change method relative for file_data_store.rb . My change was absolute_path[/^#{root_path}\/(._)$/, 1] to absolute_path[/^#{root_path}\/?(._)$/, 1]
With this its possible has an absolute path end with "/" and this method (relative) will return not nil (Its will return relative path)
