### PR TITLE
Support HEAD requests

### DIFF
--- a/lib/dragonfly/response.rb
+++ b/lib/dragonfly/response.rb
@@ -19,8 +19,9 @@ module Dragonfly
       if etag_matches?
         # Not Modified
         [304, cache_headers, []]
+      elsif request.head?
+        [200, success_headers.merge(cache_headers), []]
       else
-        # Success
         [200, success_headers.merge(cache_headers), job.result]
       end
     rescue DataStorage::DataNotFound => e


### PR DESCRIPTION
According to spec, HEAD requests shouldn't return content, and Rack::Lint complains if they do. Patch simply returns same headers and no content if the request is a HEAD request.
