### PR TITLE
Fixed dragonfly for Rails >= 3.0.2

### DIFF
--- a/lib/dragonfly/temp_object.rb
+++ b/lib/dragonfly/temp_object.rb
@@ -175,8 +175,10 @@ module Dragonfly
       when File
         @initialized_file = obj
         self.name = File.basename(obj.path)
+      when ::ActionDispatch::Http::UploadedFile
+        @initialized_tempfile = obj.tempfile
       else
-        raise ArgumentError, "#{self.class.name} must be initialized with a String, a File, a Tempfile, or another TempObject"
+        raise ArgumentError, "#{self.class.name} must be initialized with a String, a File, a Tempfile, an ActionDispatch::Http::UploadedFile or another TempObject"
       end
       self.name = obj.original_filename if obj.respond_to?(:original_filename)
     end


### PR DESCRIPTION
Just used .tempfile on ::ActionDispatch::Http::UploadedFile

All features/specs pass and RefineryCMS now functions (previously it wasn't) so the patch seems very good.

Thanks!
