### PR TITLE
job serialization/sha issue

### DIFF
--- a/lib/dragonfly/job.rb
+++ b/lib/dragonfly/job.rb
@@ -36,7 +36,7 @@ module Dragonfly
       end
 
       def initialize(*args)
-        @args = args
+        @args = args.map{ |arg| arg.is_a?(Hash) ? arg.rehash : arg }
       end
 
       attr_reader :args

--- a/spec/dragonfly/job_spec.rb
+++ b/spec/dragonfly/job_spec.rb
@@ -539,6 +539,11 @@ describe Dragonfly::Job do
       new_job = Dragonfly::Job.deserialize(@job.serialize, @app)
       new_job.to_a.should == @job.to_a
     end
+    it "should serialize the same for steps, regardless of the key order in their arg hashes" do
+      j1 = Dragonfly::Job.new(@app).fetch("weofji").process(:resize_and_crop, :width => 100, :height => 200, :gravity => "#")
+      j2 = Dragonfly::Job.from_path(j1.url, @app)
+      j2.serialize.should == j1.serialize
+    end
   end
 
   describe "to_app" do


### PR DESCRIPTION
Hi Mark,

We've been having intermittent problems with invalid shas when we have dos protection turned on. I think I got it tracked down to an issue with different serializations of essentially the same Job, depending on the order of keys in the args hash (in the case below for a "process" step).  I have some code below that demonstrates the problem we're having.  Doing a rehash on argument hashes before storing them in the Step seems to ensure better consistency.  This problem may be exclusive to ruby 1.8.7 since hashes are ordered in 1.9.

```
#Loading development environment (Rails 3.0.2)
app = Dragonfly::App.send(:new)
j = Dragonfly::Job.new(app)
  #<Dragonfly::Job:0x1079aca60 app=#<Dragonfly::App:0x1079b1d30>, steps=[], temp_object=nil, steps applied:0/0 >
j = j.fetch("/some/path").process(:resize_and_crop, :width => 950, :height => 320, :gravity => "#")
  #<Dragonfly::Job:0x10799f130 app=#<Dragonfly::App:0x1079b1d30>, steps=[fetch("/some/path"), process(:resize_and_crop, {:gravity=>"#", :height=>320, :width=>950})], temp_object=nil, steps applied:0/2 >
new_job = Dragonfly::Job.from_path(j.url, app)
  #<Dragonfly::Job:0x107997e58 app=#<Dragonfly::App:0x1079b1d30>, steps=[fetch("/some/path"), process(:resize_and_crop, {:gravity=>"#", :width=>950, :height=>320})], temp_object=nil, steps applied:0/2 >
j.serialize
 #"BAhbB1sHOgZmIg8vc29tZS9wYXRoWwg6BnA6FHJlc2l6ZV9hbmRfY3JvcHsIOgxncmF2aXR5IgYjOgtoZWlnaHRpAkABOgp3aWR0aGkCtgM"
new_job.serialize
 #"BAhbB1sHOgZmIg8vc29tZS9wYXRoWwg6BnA6FHJlc2l6ZV9hbmRfY3JvcHsIOgxncmF2aXR5IgYjOgp3aWR0aGkCtgM6C2hlaWdodGkCQAE"
j.serialize == new_job.serialize
 # false
```

I'm not completely happy with this fix because I am still not sure that I completely understand all of the workings behind this problem, but I'd be interested in hearing about what you think.

August
