### PR TITLE
configurable root response

### DIFF
--- a/lib/dragonfly/app.rb
+++ b/lib/dragonfly/app.rb
@@ -63,7 +63,8 @@ module Dragonfly
     configuration_method :processor
     configuration_method :encoder
     configuration_method :generator
-
+    configuration_method :server
+    
     attr_accessor :job_definitions
 
     SAVED_CONFIGS = {

--- a/lib/dragonfly/simple_endpoint.rb
+++ b/lib/dragonfly/simple_endpoint.rb
@@ -2,7 +2,10 @@ module Dragonfly
   class SimpleEndpoint
 
     include Loggable
+    include Configurable
 
+    configurable_attr :root_response do dragonfly_response end
+    
     # Instance methods
 
     def initialize(app)
@@ -15,7 +18,7 @@ module Dragonfly
 
       case request.path_info
       when '', '/', app.url_path_prefix
-        dragonfly_response
+        root_response
       else
         job = Job.from_path(request.path_info, app)
         job.validate_sha!(request['s']) if app.protect_from_dos_attacks
@@ -38,7 +41,7 @@ module Dragonfly
 
     attr_reader :app
 
-    def dragonfly_response
+    def self.dragonfly_response
       body = <<-DRAGONFLY
           _o|o_
   _~~---._(   )_.---~~_

--- a/spec/dragonfly/simple_endpoint_spec.rb
+++ b/spec/dragonfly/simple_endpoint_spec.rb
@@ -69,10 +69,17 @@ describe Dragonfly::SimpleEndpoint do
     response.body.should == 'HELLO THERE'
   end
 
-  it "should return a simple text response at the root" do
+  it "should return a simple text response at the root by default" do
     response = request(@endpoint, '/')
     response.status.should == 200
     response.body.length.should > 0
+    response.content_type.should == 'text/plain'
+  end
+
+  it "should return the configured response if configured" do
+    @endpoint.root_response = [404, {'Content-Type' => 'text/plain'}, ['Not found']]
+    response = request(@endpoint, '/')
+    response.status.should == 404
     response.content_type.should == 'text/plain'
   end
 


### PR DESCRIPTION
added code to make the root response configurable. I think the dragonfly is a great response and in most cases is just fine, but in our case we expect a 404 so we need to be able to configure it. Added tests as well. let me know if I need to do more, or if I got something wrong.
