### PR TITLE
Added strip command to  image_magick processor

### DIFF
--- a/lib/dragonfly/image_magick/processor.rb
+++ b/lib/dragonfly/image_magick/processor.rb
@@ -71,6 +71,10 @@ module Dragonfly
       def rotate(temp_object, amount, opts={})
         convert(temp_object, "-rotate '#{amount}#{opts[:qualifier]}'")
       end
+
+      def strip(temp_object)
+        convert(temp_object, "-strip")
+      end   
       
       def thumb(temp_object, geometry)
         case geometry


### PR DESCRIPTION
Hi!
In my application i send emails with attached images. I use dragonfly to store these images. I figured that some images contained a lot of meta information. With the strip command i could reduce the total size of 40 images attached to the email from 2 mb down to 200kb. Maybe its also useful for other people to reduce their image sizes if necessary.

Greetings

Holger
