### PR TITLE
add a catch(:halt) like sinatra to allow stoping execution from the befor

### DIFF
--- a/lib/dragonfly/server.rb
+++ b/lib/dragonfly/server.rb
@@ -30,10 +30,12 @@ module Dragonfly
         job = Job.deserialize(params['job'], app)
         job.validate_sha!(params['sha']) if protect_from_dos_attacks
         response = Response.new(job, env)
-        if before_serve_callback && response.served?
-          before_serve_callback.call(job, env)
+        catch(:halt) do
+          if before_serve_callback && response.served?
+            before_serve_callback.call(job, env)
+          end
+          response.to_response
         end
-        response.to_response
       else
         [404, {'Content-Type' => 'text/plain', 'X-Cascade' => 'pass'}, ['Not found']]
       end

--- a/spec/dragonfly/server_spec.rb
+++ b/spec/dragonfly/server_spec.rb
@@ -199,32 +199,53 @@ describe Dragonfly::Server do
     end
 
   end
-  
+
   describe "before_serve callback" do
-    
-    before(:each) do
-      @app = test_app
-      @app.generator.add(:test){ "TEST" }
-      @server = Dragonfly::Server.new(@app)
-      @job = @app.generate(:test)
-      @x = x = ""
-      @server.before_serve do |job, env|
-        x << job.data
+
+    context "with no stop in the callback" do
+      before(:each) do
+        @app = test_app
+        @app.generator.add(:test){ "TEST" }
+        @server = Dragonfly::Server.new(@app)
+        @job = @app.generate(:test)
+        @x = x = ""
+        @server.before_serve do |job, env|
+          x << job.data
+        end
+      end
+
+      it "should be called before serving" do
+        response = request(@server, "/#{@job.serialize}")
+        response.body.should == 'TEST'
+        @x.should == 'TEST'
+      end
+
+      it "should not be called before serving a 404 page" do
+        response = request(@server, "blah")
+        response.status.should == 404
+        @x.should == ""
       end
     end
 
-    it "should be called before serving" do
-      response = request(@server, "/#{@job.serialize}")
-      response.body.should == 'TEST'
-      @x.should == 'TEST'
+    context "with a throw :halt in the callback" do
+      before(:each) do
+        @app = test_app
+        @app.generator.add(:test){ "TEST" }
+        @server = Dragonfly::Server.new(@app)
+        @job = @app.generate(:test)
+        @x = x = ""
+        @server.before_serve do |job, env|
+          x << job.data
+          throw :halt, [200, {}, 'hello']
+        end
+      end
+      it 'return the response instead the job.result' do
+        response = request(@server, "/#{@job.serialize}")
+        response.body.should == 'hello'
+        @x.should == 'TEST'
+      end
     end
-    
-    it "should not be called before serving a 404 page" do
-      response = request(@server, "blah")
-      response.status.should == 404
-      @x.should == ""
-    end
-    
+
   end
-  
+
 end


### PR DESCRIPTION
add a catch(:halt) like sinatra to allow stoping execution from the before_serve_callback

The before_server_callback alllow adding some information. But there are no system to stop execution and render something else. Now we can do it. By example :

```
@server.before_serve do |job, env|                                                                                                                                          
  x << job.data                                                                                                                                                             
  throw :halt, [200, {}, 'hello']                                                                                                                                           
end 
```

In this case the return is only 200 with 'hello' like body. I get the same system than sinatra.
