### PR TITLE
Multiple crops on same image

### DIFF
--- a/lib/dragonfly/image_magick/processor.rb
+++ b/lib/dragonfly/image_magick/processor.rb
@@ -34,7 +34,7 @@ module Dragonfly
         x = '+' + x unless x[/^[+-]/]
         y       = "#{opts[:y] || 0}"
         y = '+' + y unless y[/^[+-]/]
-        repage  = opts[:reset_dimensions] == false ? '' : '+repage'
+        repage  = opts[:reset_geometry] == false ? '' : '+repage'
     
         convert(temp_object, "-crop #{width}x#{height}#{x}#{y}#{" -gravity #{gravity}" if gravity} #{repage}")
       end

--- a/spec/dragonfly/image_magick/processor_spec.rb
+++ b/spec/dragonfly/image_magick/processor_spec.rb
@@ -124,10 +124,10 @@ describe Dragonfly::ImageMagick::Processor do
       image2.should have_height(50)
     end
 
-    it "should crop twice in a row while consciously keeping dimensions" do
+    it "should crop twice in a row while consciously keeping page geometry" do
       # see http://www.imagemagick.org/Usage/crop/#crop_page
       # it explains how cropping multiple times without resetting geometry behaves
-      image1 = @processor.crop(@image,  :x => '10', :y => '10', :width => '100', :height => '100', :reset_dimensions => false)
+      image1 = @processor.crop(@image,  :x => '10', :y => '10', :width => '100', :height => '100', :reset_geometry => false)
       @image1 = Dragonfly::TempObject.new(image1)
       image2 = @processor.crop(@image1, :x => '0' , :y => '0' , :width => '50' , :height => '50')
       image2.should have_width(40)


### PR DESCRIPTION
ImageMagick behaves unexpectedly when cropping images multiple times in a row. To avoid this, IM supports the `+repage` parameter. I added support for that operator.

Furthermore, I think it is save to enable `+repage` by default as it mirrors expected behaviour (and no other tests fail). But ymmv :)
