### PR TITLE
Change order of arguments to 'convert' system command

### DIFF
--- a/spec/dragonfly/image_magick/processor_spec.rb
+++ b/spec/dragonfly/image_magick/processor_spec.rb
@@ -238,6 +238,11 @@ describe Dragonfly::ImageMagick::Processor do
       image.should have_format('gif')
       extra[:format].should == :gif
     end
+
+    it "should work for commands with parenthesis" do
+      image = @processor.convert(@image, "\\( +clone -sparse-color Barycentric '0,0 black 0,%[fx:h-1] white' -function polynomial 2,-2,0.5 \\) -compose Blur -set option:compose:args 15 -composite")
+      image.should have_width(280)
+    end
   end
   
 end

--- a/spec/dragonfly/image_magick/utils_spec.rb
+++ b/spec/dragonfly/image_magick/utils_spec.rb
@@ -15,8 +15,4 @@ describe Dragonfly::ImageMagick::Utils do
     end
   end
 
-  it "should work for commands with parenthesis" do
-    expect { @obj.send(:run, "\\( +clone -sparse-color Barycentric '0,0 black 0,%[fx:h-1] white' -function polynomial 2,-2,0.5 \\) -compose Blur -set option:compose:args 15 -composite") }.to_not raise_error
-  end
-
 end


### PR DESCRIPTION
According to the `convert` man page, output options should follow the input file:

```
SYNOPSIS
   convert [input-options] input-file [output-options] output-file
```

I have seen examples that run `convert` with the input file listed right before the output (i.e. Dragonfly) and it works fine for most cases, but I was trying to do the [tilt-shift example](http://www.imagemagick.org/Usage/photos/#tilt_shift) from the imagemagick site, and it would fail with a `Dragonfly::FunctionManager::UnableToHandle` exception.  I added a spec for this specific example, though it may be good to come up with something simpler.
