### PR TITLE
Fixing issue 74. Single quotes do not group words into a single command l

### DIFF
--- a/lib/dragonfly/image_magick/processor.rb
+++ b/lib/dragonfly/image_magick/processor.rb
@@ -23,7 +23,7 @@ module Dragonfly
       include Utils
       
       def resize(temp_object, geometry)
-        convert(temp_object, "-resize '#{geometry}'")
+        convert(temp_object, "-resize \"#{geometry}\"")
       end
       
       def crop(temp_object, opts={})
@@ -69,7 +69,7 @@ module Dragonfly
       end
       
       def rotate(temp_object, amount, opts={})
-        convert(temp_object, "-rotate '#{amount}#{opts[:qualifier]}'")
+        convert(temp_object, "-rotate \"#{amount}#{opts[:qualifier]}\"")
       end
 
       def strip(temp_object)


### PR DESCRIPTION
Fixing issue 74. Single quotes do not group words into a single command line argument in Windows like they do in Unix.
