### PR TITLE
Improved performance of resize_and_crop

### DIFF
--- a/lib/dragonfly/image_magick/processor.rb
+++ b/lib/dragonfly/image_magick/processor.rb
@@ -35,8 +35,9 @@ module Dragonfly
         y       = "#{opts[:y] || 0}"
         y = '+' + y unless y[/^[+-]/]
         repage  = opts[:repage] == false ? '' : '+repage'
+        resize  = opts[:resize]
     
-        convert(temp_object, "-crop #{width}x#{height}#{x}#{y}#{" -gravity #{gravity}" if gravity} #{repage}")
+        convert(temp_object, "#{"-resize #{resize} " if resize}#{"-gravity #{gravity} " if gravity}-crop #{width}x#{height}#{x}#{y} #{repage}")
       end
       
       def flip(temp_object)
@@ -53,20 +54,18 @@ module Dragonfly
       alias grayscale greyscale
       
       def resize_and_crop(temp_object, opts={})
-        attrs          = identify(temp_object)
-        current_width  = attrs[:width].to_i
-        current_height = attrs[:height].to_i
-        
-        width   = opts[:width]  ? opts[:width].to_i  : current_width
-        height  = opts[:height] ? opts[:height].to_i : current_height
-        gravity = opts[:gravity] || 'c'
-
-        if width != current_width || height != current_height
-          scale = [width.to_f / current_width, height.to_f / current_height].max
-          temp_object = TempObject.new(resize(temp_object, "#{(scale * current_width).ceil}x#{(scale * current_height).ceil}"))
+        if !opts[:width] && !opts[:height]
+          return temp_object
+        elsif !opts[:width] || !opts[:height]
+          attrs          = identify(temp_object)
+          opts[:width]   ||= attrs[:width]
+          opts[:height]  ||= attrs[:height]
         end
 
-        crop(temp_object, :width => width, :height => height, :gravity => gravity)
+        opts[:gravity] ||= 'c'
+
+        opts[:resize]  = "#{opts[:width]}x#{opts[:height]}^"
+        crop(temp_object, opts)
       end
       
       def rotate(temp_object, amount, opts={})

--- a/spec/dragonfly/image_magick/processor_spec.rb
+++ b/spec/dragonfly/image_magick/processor_spec.rb
@@ -103,7 +103,7 @@ describe Dragonfly::ImageMagick::Processor do
     it "should take into account the gravity given" do
       image1 = @processor.crop(@image, :width => '10', :height => '10', :gravity => 'nw')
       image2 = @processor.crop(@image, :width => '10', :height => '10', :gravity => 'se')
-      image1.should_not == image2
+      Digest::MD5.hexdigest(File.read(image1)).should_not == Digest::MD5.hexdigest(File.read(image2))
     end
 
     it "should clip bits of the image outside of the requested crop area when not nw gravity" do
@@ -147,10 +147,23 @@ describe Dragonfly::ImageMagick::Processor do
       image.should have_height(355)
     end
 
+    it "should do nothing if called without width and height" do
+      image = @processor.resize_and_crop(@image)
+      image.should have_width(280)
+      image.should have_height(355)
+      image.should eq @image
+    end
+
     it "should crop to the correct dimensions" do
       image = @processor.resize_and_crop(@image, :width => '100', :height => '100')
       image.should have_width(100)
       image.should have_height(100)
+    end
+
+    it "should actually resize before cropping" do
+      image1 = @processor.resize_and_crop(@image, :width => '100', :height => '100')
+      image2 = @processor.crop(@image, :width => '100', :height => '100', :gravity => 'c')
+      Digest::MD5.hexdigest(File.read(image1)).should_not == Digest::MD5.hexdigest(File.read(image2))
     end
 
     it "should allow cropping in one dimension" do
@@ -162,7 +175,7 @@ describe Dragonfly::ImageMagick::Processor do
     it "should take into account the gravity given" do
       image1 = @processor.resize_and_crop(@image, :width => '10', :height => '10', :gravity => 'nw')
       image2 = @processor.resize_and_crop(@image, :width => '10', :height => '10', :gravity => 'se')
-      image1.should_not == image2
+      Digest::MD5.hexdigest(File.read(image1)).should_not == Digest::MD5.hexdigest(File.read(image2))
     end
 
   end


### PR DESCRIPTION
This patch improves performance of resize_and_crop by removing 2 out of 3 calls to ImageMagick.

Also it allows to resize and crop at the same time by passing a :resize option into crop(). (This is actually how the refactored resize_and_crop works.)
Because of the refactoring resize_and_crop accepts the same options as crop now. :x and :y for example.

Also for cropping the -gravity option is now before -crop in the IM call as it should be.

In the process two tests that compared files got improved by using md5 hashes for comparison.
