### PR TITLE
Doc fix (link)

### DIFF
--- a/extra_docs/Generators.md
+++ b/extra_docs/Generators.md
@@ -17,7 +17,7 @@ where `:some_method` is added by the configured generators.
 
 ImageMagick Generator
 ---------------------
-See {file:Imagemagick}.
+See {file:ImageMagick}.
 
 Custom Generators
 -----------------


### PR DESCRIPTION
The link to ImageMagic on the Generators page was busted, this fixes. Yay, a 1 character commit!
