### PR TITLE
avoid marshal the metadata in GridfsStore because manage well hash access

### DIFF
--- a/lib/dragonfly/data_storage/mongo_data_store.rb
+++ b/lib/dragonfly/data_storage/mongo_data_store.rb
@@ -1,5 +1,4 @@
 require 'mongo'
-require 'active_support/hash_with_indifferent_access'
 
 module Dragonfly
   module DataStorage
@@ -43,7 +42,7 @@ module Dragonfly
         grid_io = grid.get(bson_id(uid))
         [
           grid_io.read,
-          ActiveSupport::HashWithIndifferentAccess.new(grid_io.metadata.merge(:stored_at => grid_io.upload_date))
+          grid_io.metadata.merge(:stored_at => grid_io.upload_date)
         ]
       rescue Mongo::GridFileNotFound, INVALID_OBJECT_ID => e
         raise DataNotFound, "#{e} - #{uid}"

--- a/spec/dragonfly/data_storage/shared_data_store_examples.rb
+++ b/spec/dragonfly/data_storage/shared_data_store_examples.rb
@@ -45,13 +45,13 @@ shared_examples_for "data_store" do
     describe "when meta is given" do
       before(:each) do
         temp_object = Dragonfly::TempObject.new('gollum')
-        @uid = @data_store.store(temp_object, :meta => {:bitrate => '35', :name => 'danny.boy'})
+        @uid = @data_store.store(temp_object, :meta => {'bitrate' => '35', 'name' => 'danny.boy'})
         @obj, @meta = @data_store.retrieve(@uid)
       end
 
       it "should return the stored meta" do
-        @meta[:bitrate].should == '35'
-        @meta[:name].should == 'danny.boy'
+        @meta['bitrate'].should == '35'
+        @meta['name'].should == 'danny.boy'
       end
     end
 


### PR DESCRIPTION
avoid marshal the metadata in GridfsStore because manage well hash access
