### PR TITLE
Shell out vulnerability detected

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source :rubygems
 
 gem "rack"
+gem 'escape'
 
 # These gems are needed for development and testing
 group :development, :test, :cucumber do

--- a/lib/dragonfly.rb
+++ b/lib/dragonfly.rb
@@ -30,6 +30,7 @@ end
 
 autoload_files_in_dir("#{File.dirname(__FILE__)}/dragonfly", 'Dragonfly')
 
+require 'escape'
 require 'dragonfly/core_ext/object'
 require 'dragonfly/core_ext/string'
 require 'dragonfly/core_ext/symbol'

--- a/lib/dragonfly/image_magick/processor.rb
+++ b/lib/dragonfly/image_magick/processor.rb
@@ -37,7 +37,7 @@ module Dragonfly
         repage  = opts[:repage] == false ? '' : '+repage'
         resize  = opts[:resize]
     
-        convert(temp_object, "#{"-resize #{resize} " if resize}#{"-gravity #{gravity} " if gravity}-crop #{width}x#{height}#{x}#{y} #{repage}")
+        convert(temp_object, "#{"-resize #{Escape.shell_command([resize])} " if resize}#{"-gravity #{gravity} " if gravity}-crop #{width}x#{height}#{x}#{y} #{repage}")
       end
       
       def flip(temp_object)


### PR DESCRIPTION
A work buddy of mine here at Zweitag discovered this yesterday. Dragonfly::ImageMagick::Processor.crop method has a shell out vulnerability.

By invoking the crop method with a well crafted URL in the resize option an attacker can run arbitrary shell commands. 
- I changed it to escape shell arguments, i.e. the resize option, with the escape gem
