### PR TITLE
Allow Rack::Test::UploadedFile as a TempObject

### DIFF
--- a/lib/dragonfly/temp_object.rb
+++ b/lib/dragonfly/temp_object.rb
@@ -62,8 +62,12 @@ module Dragonfly
         @original_filename = @pathname.basename.to_s
       elsif obj.respond_to?(:tempfile)
         @tempfile = obj.tempfile
+      elsif obj.respond_to?(:path) && obj.respond_to?(:original_filename)
+        # Rack::Test::UploadedFile from Rack / Rails functional tests
+        @pathname = Pathname.new(obj.path)
+        @original_filename = obj.original_filename
       else
-        raise ArgumentError, "#{self.class.name} must be initialized with a String, a Pathname, a File, a Tempfile, another TempObject, or something that responds to .tempfile"
+        raise ArgumentError, "#{self.class.name} must be initialized with a String, a Pathname, a File, a Tempfile, another TempObject, something that responds to .tempfile, or something that responds to .path and .original_filename"
       end
       @tempfile.close if @tempfile
       @original_filename = obj.original_filename if obj.respond_to?(:original_filename)

--- a/spec/dragonfly/temp_object_spec.rb
+++ b/spec/dragonfly/temp_object_spec.rb
@@ -310,6 +310,26 @@ describe Dragonfly::TempObject do
     end
   end
 
+  describe "initialize from a Rack::Test::UploadedFile" do
+    def initialization_object(data)
+      # The criteria we're using to determine if an object is a
+      # Rack::Test::UploadedFile is if it responds to path and original_filename.
+      #
+      # We can't just check if it is_a?(Rack::Test::UploadedFile) because that
+      # class may not always be present.
+      uploaded_file = mock("mock_uploadedfile")
+      uploaded_file.stub!(:path).and_return('/tmp/test_file')
+      uploaded_file.stub!(:original_filename).and_return('foo.jpg')
+
+      # Create a real file with the contents required at the correct path
+      new_file(data, '/tmp/test_file')
+
+      uploaded_file
+    end
+
+    it_should_behave_like "common behaviour"
+  end
+
   describe "original_filename" do
     before(:each) do
       @obj = new_tempfile


### PR DESCRIPTION
Up until now, I've been exploiting the fact that Rails will pass objects to the controller as parameters in functional tests, e.g.:

```
post :create, :model => {:image => File.new('/path/to/testimage.png')}
```

and the `File` instance has been passed through the stack to Dragonfly untouched.

However, since Rails 3.1.0rc5, this loophole has been shut, and Rails now sanitizes the parameters.  So now, Rails is converting the `File` object to a string like `#<File:0x00000003c1bc38>`, which basically breaks everything.

The relevant commit in Rails is https://github.com/rails/rails/commit/7fd726d62e8483c5bdb39c7f5b9d267e6b7fbaa6

This change allows Dragonfly to accept instances of `Rack::Test::UploadedFile`, which is the standard way of simulating a file upload in Rails functional tests.
