### PR TITLE
Rails' accepts_nested_attributes_for conflicts with dragonfly active model macros

### DIFF
--- a/lib/dragonfly/active_model_extensions/attachment.rb
+++ b/lib/dragonfly/active_model_extensions/attachment.rb
@@ -54,6 +54,7 @@ module Dragonfly
           self.class.run_callbacks(:after_assign, model, self) if should_run_callbacks?
           retain! if should_retain?
         end
+        model_uid_will_change!
         value
       end
 
@@ -210,6 +211,10 @@ module Dragonfly
         model.send("#{attribute}_uid")
       end
 
+      def model_uid_will_change!
+        model.send("#{attribute}_uid_will_change!")
+      end
+      
       attr_reader :model, :uid
       attr_writer :job
       attr_accessor :previous_uid

--- a/spec/dragonfly/active_model_extensions/model_spec.rb
+++ b/spec/dragonfly/active_model_extensions/model_spec.rb
@@ -222,6 +222,7 @@ describe Item do
           @app.datastore.should_receive(:destroy).with('some_uid')
           @item.save!
         end
+        
         it "should not try to destroy the old data if saved again" do
           @app.datastore.should_receive(:destroy).with('some_uid')
           @item.save!
@@ -257,6 +258,10 @@ describe Item do
         it "should return the new data" do
           @item.preview_image.data.should == 'ANEWDATASTRING'
         end
+
+        it 'should mark the attribute as changed' do
+          @item.preview_image_uid_changed?.should be_true
+        end
       end
 
       describe "when it is set to nil" do
@@ -278,6 +283,11 @@ describe Item do
           @app.datastore.should_receive(:destroy).with('some_uid')
           @item.destroy
         end
+        
+        it 'should mark the attribute as changed' do
+          @item.preview_image_uid_changed?.should be_true
+        end
+        
       end
 
       describe "when the data can't be found" do

--- a/spec/dragonfly/active_model_extensions/spec_helper.rb
+++ b/spec/dragonfly/active_model_extensions/spec_helper.rb
@@ -11,6 +11,7 @@ class MyModel
   define_model_callbacks :save, :destroy
   
   include ActiveModel::Validations
+  include ActiveModel::Dirty
   
   class << self
     def create!(attrs={})
@@ -73,6 +74,7 @@ class Item < MyModel
     :created_at,
     :updated_at
   ]
+  define_attribute_methods ATTRIBUTES
   attr_accessor *ATTRIBUTES
 end
 
@@ -82,10 +84,12 @@ class Car < MyModel
     :reliant_image_uid,
     :type
   ]
+  define_attribute_methods ATTRIBUTES
   attr_accessor *ATTRIBUTES
 end
 
 class Photo < MyModel
   ATTRIBUTES = [:image_uid]
+  define_attribute_methods ATTRIBUTES
   attr_accessor *ATTRIBUTES
 end


### PR DESCRIPTION
if Collection has many Photos, photos has a dragonfly attachment, and 
collection has accepts_nested_attributes_for :photos and on your form 
you edit an existing photo (but only changing the image) then the 
image won't get saved. 

From my investigation this occurs because when you save the parent 
record, save is called on the associated records via 
autosave_association, which checks whether to save by calling the 
changed_for_autosave? method which checks whether the record is new, 
changed or has changed nested associations. Because dragonfly hasn't 
yet assigned to the _uid column, changed_for_autosave? returns false 
and save never gets called on the photo object. 

I've made dragonfly call the blah_uid_will_change! method. This introduces the requirement that the class in question supports ActiveModel::Dirty - not a problem with an ActiveRecord or MongoMapper class, but potentially problematic if using dragonfly with some barebones class that only implemented small parts of ActiveModel
