### PR TITLE
File extensions with numbers

### DIFF
--- a/lib/dragonfly/image_magick/utils.rb
+++ b/lib/dragonfly/image_magick/utils.rb
@@ -21,7 +21,7 @@ module Dragonfly
       def identify(temp_object)
         # example of details string:
         # myimage.png PNG 200x100 200x100+0+0 8-bit DirectClass 31.2kb
-        format, width, height, depth = raw_identify(temp_object).scan(/([A-Z]+) (\d+)x(\d+) .+ (\d+)-bit/)[0]
+        format, width, height, depth = raw_identify(temp_object).scan(/([A-Z0-9]+) (\d+)x(\d+) .+ (\d+)-bit/)[0]
         {
           :format => format.downcase.to_sym,
           :width => width.to_i,


### PR DESCRIPTION
I have changed the regular expresion that extracts format, width, height, depth to recognize file extensions with numbers. I had the problem with JP2 files (JPEG 2000).
