### PR TITLE
Use actual temp_object reference as cache key.

### DIFF
--- a/lib/dragonfly/analyser.rb
+++ b/lib/dragonfly/analyser.rb
@@ -21,7 +21,7 @@ module Dragonfly
     
     def analyse(temp_object, method, *args)
       if enable_cache
-        key = [temp_object.object_id, method, *args]
+        key = [temp_object, method, *args]
         cache[key] ||= call_last(method, temp_object, *args)
       else
         call_last(method, temp_object, *args)


### PR DESCRIPTION
Fixes #135.  Will stop GC from collecting the temp_objects though,
I'm not sure what impact this will have for a long running process.

I actually think this whole caching strategy is not as effective as it could be.  I think it would be better to create a cache of calls to `identify`, as this is the most expensive operation in the whole process.

At the moment, calling `obj.image.width` and `obj.image.height` will cause `identify` to be called twice with the same arguments and the same result.  The first call has all of the required data, but only the `width` gets cached and the rest is discarded.  I may create a separate pull request to cache results from `raw_identify`.
