### PR TITLE
Set TempObject File.open mode

### DIFF
--- a/lib/dragonfly/temp_object.rb
+++ b/lib/dragonfly/temp_object.rb
@@ -118,7 +118,7 @@ module Dragonfly
 
     def to_file(path)
       if @data
-        File.open(path, 'wb'){|f| f.write(@data) }
+        File.open(path, 'wb', 0644){|f| f.write(@data) }
       else
         FileUtils.cp(self.path, path)
         File.chmod(0644, path)


### PR DESCRIPTION
Explicitly set the mode to File.open, otherwise the process umask
will be used.

In the case of my system, this is 664, which causes the `TempObject` file permission checks to fail in the specs.
