### PR TITLE
Inconsistency between hash generated in spec and actual hash shown in view in Ruby 1.9.2+

### DIFF
--- a/fixtures/rails/files/features/manage_album_images.feature
+++ b/fixtures/rails/files/features/manage_album_images.feature
@@ -8,6 +8,7 @@ Feature: champion adds cover images to his albums
     And I press "Create"
     Then I should see "successfully created"
     And I should see "Look at this cover image!"
+    And the hash shown in the view should be the same as in the spec
     When I look at the generated image
     Then I should see a PNG image of size 200x100
 

--- a/fixtures/rails/files/features/step_definitions/image_steps.rb
+++ b/fixtures/rails/files/features/step_definitions/image_steps.rb
@@ -23,3 +23,9 @@ Then /^I should see a (.+) image of size (.+)$/ do |format, size|
   output[1].should == format
   output[2].should == size
 end
+
+Then /^the hash shown in the view should be the same as in the spec$/ do
+  @album = Album.last
+  image_url = @album.cover_image.thumb('200x100!').url
+  page.should have_css("img[src='#{image_url}']")
+end


### PR DESCRIPTION
I am using rspec request specs to test for the presence of a particular dragonfly image like this:

``` ruby
page.should have_css("img[src='#{post.photo.thumb('100x100')}']")
```

but for some reason even though the exact same code is found in the view, the spec fails because the hash generated in the spec and the one actually shown in the view are different.

The test passes in 1.8.7 but fails in 1.9.2+

I am not sure how the hashes are generated so just added a spec for now, but do you have any idea why that might be the case (or any workarounds to test for the presence of dragonfly images in the view?)

The difference is a matter of only 3 characters ("GVF" vs "GRl" in the middle of the url): 

VIEW:
http://www.example.com/media/BAhbCVsHOgZmSSImMjAxMS8xMS8yMi8xNl8wM18zNV85ODlfcGhvdG8uanBnBjoGRVRbCDoGcDoMY29udmVydEkiES1hdXRvLW9yaWVudAY7BkZbCDsHOgp0aHVtYkkiDTEwMHgxMDAjBjsGVFsIOgZlOghqcGdJIhctc3RyaXAgLXF1YWxpdHkgODAGOwZG.jpg

SPEC:
http://www.example.com/media/BAhbCVsHOgZmSSImMjAxMS8xMS8yMi8xNl8wM18zNV85ODlfcGhvdG8uanBnBjoGRVRbCDoGcDoMY29udmVydEkiES1hdXRvLW9yaWVudAY7BkZbCDsHOgp0aHVtYkkiDTEwMHgxMDAjBjsGRlsIOgZlOghqcGdJIhctc3RyaXAgLXF1YWxpdHkgODAGOwZG.jpg
