### PR TITLE
GFMD syntax highlighting for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,73 +11,95 @@ For the lazy Rails user...
 --------------------------
 **Gemfile**:
 
-    gem 'rack-cache', :require => 'rack/cache'
-    gem 'dragonfly', '~>0.9.8'
+```ruby
+gem 'rack-cache', :require => 'rack/cache'
+gem 'dragonfly', '~>0.9.8'
+```
 
 **Initializer** (e.g. config/initializers/dragonfly.rb):
 
-    require 'dragonfly/rails/images'
+```ruby
+require 'dragonfly/rails/images'
+```
 
 **Migration**:
 
-    add_column :albums, :cover_image_uid,  :string
-    add_column :albums, :cover_image_name, :string  # Optional - only if you want urls
-                                                    # to end with the original filename
+```ruby
+add_column :albums, :cover_image_uid,  :string
+add_column :albums, :cover_image_name, :string  # Optional - only if you want urls
+                                                # to end with the original filename
+```
 
 **Model**:
 
-    class Album < ActiveRecord::Base
-      image_accessor :cover_image            # 'image_accessor' is provided by Dragonfly
-                                             # this defines a reader/writer for cover_image
-      # ...
-    end
+```ruby
+class Album < ActiveRecord::Base
+  image_accessor :cover_image            # 'image_accessor' is provided by Dragonfly
+                                         # this defines a reader/writer for cover_image
+  # ...
+end
+```
 
 **View** (for uploading via a file field):
 
-    <% form_for @album, :html => {:multipart => true} do |f| %>
-      ...
-      <%= f.file_field :cover_image %>
-      ...
-    <% end %>
+```erb
+<% form_for @album, :html => {:multipart => true} do |f| %>
+  ...
+  <%= f.file_field :cover_image %>
+  ...
+<% end %>
+```
 
 NB: REMEMBER THE MULTIPART BIT!!!
 
 You can avoid having to re-upload when validations fail with
 
-      <%= f.hidden_field :retained_cover_image %>
+```erb
+  <%= f.hidden_field :retained_cover_image %>
+```
 
 remove the attachment with
 
-      <%= f.check_box :remove_cover_image %>
+```erb
+  <%= f.check_box :remove_cover_image %>
+```
 
 assign from some other url with
 
-      <%= f.text_field :cover_image_url %>
+```erb
+  <%= f.text_field :cover_image_url %>
+```
 
 and display a thumbnail (on the upload form) with
 
-      <%= image_tag @album.cover_image.thumb('100x100').url if @album.cover_image_uid %>
+```erb
+  <%= image_tag @album.cover_image.thumb('100x100').url if @album.cover_image_uid %>
+```
 
 **View** (to display):
 
-    <%= image_tag @album.cover_image.url %>
-    <%= image_tag @album.cover_image.thumb('400x200#').url %>
-    <%= image_tag @album.cover_image.jpg.url %>
-    <%= image_tag @album.cover_image.process(:greyscale).encode(:tiff).url %>
-    ...etc.
+```erb
+<%= image_tag @album.cover_image.url %>
+<%= image_tag @album.cover_image.thumb('400x200#').url %>
+<%= image_tag @album.cover_image.jpg.url %>
+<%= image_tag @album.cover_image.process(:greyscale).encode(:tiff).url %>
+...etc.
+```
 
 The above relies on imagemagick being installed. Dragonfly doesn't depend on it per se, but the default configuration `'dragonfly/rails/images'`
 uses it. For alternative configurations, see below.
 
 If using Capistrano with the above, you probably will want to keep the cache between deploys, so in deploy.rb:
 
-    namespace :dragonfly do
-      desc "Symlink the Rack::Cache files"
-      task :symlink, :roles => [:app] do
-        run "mkdir -p #{shared_path}/tmp/dragonfly && ln -nfs #{shared_path}/tmp/dragonfly #{release_path}/tmp/dragonfly"
-      end
-    end
-    after 'deploy:update_code', 'dragonfly:symlink'
+```ruby
+namespace :dragonfly do
+  desc "Symlink the Rack::Cache files"
+  task :symlink, :roles => [:app] do
+    run "mkdir -p #{shared_path}/tmp/dragonfly && ln -nfs #{shared_path}/tmp/dragonfly #{release_path}/tmp/dragonfly"
+  end
+end
+after 'deploy:update_code', 'dragonfly:symlink'
+```
 
 Sinatra, CouchDB, Mongo, Rack, S3, custom storage, processing, and more...
 --------------------------------------------------------------------------


### PR DESCRIPTION
I jumped onto the dragonfly github page today looking to get oriented on dragonfly.  My heart sunk when I was greeted with a wall of gray text.  I added some [GitHub-Flavored Markdown](http://github.github.com/github-flavored-markdown/) syntax highlighting to alleviate the trouble.  See [brianhempel/dragonfly](https://github.com/brianhempel/dragonfly) to view the re-colored README.
