### PR TITLE
Add support to File data store for files that do not have a directory prefix in their path

### DIFF
--- a/lib/dragonfly/data_storage/file_data_store.rb
+++ b/lib/dragonfly/data_storage/file_data_store.rb
@@ -81,7 +81,7 @@ module Dragonfly
       private
 
       def absolute(relative_path)
-        File.join(root_path, relative_path)
+        relative_path.to_s == '.' ? root_path : File.join(root_path, relative_path)
       end
 
       def relative(absolute_path)
@@ -90,6 +90,10 @@ module Dragonfly
 
       def directory_empty?(path)
         Dir.entries(path) == ['.','..']
+      end
+      
+      def root_path?(dir)
+        root_path == dir
       end
 
       def meta_data_path(data_path)
@@ -126,7 +130,7 @@ module Dragonfly
         containing_directory = Pathname.new(path).dirname
         containing_directory.ascend do |relative_dir|
           dir = absolute(relative_dir)
-          FileUtils.rmdir dir if directory_empty?(dir)
+          FileUtils.rmdir dir if directory_empty?(dir) && !root_path?(dir)
         end
       end
 

--- a/spec/dragonfly/data_storage/file_data_store_spec.rb
+++ b/spec/dragonfly/data_storage/file_data_store_spec.rb
@@ -174,6 +174,12 @@ describe Dragonfly::DataStorage::FileDataStore do
       @data_store.destroy(uid)
       @data_store.root_path.should be_an_empty_directory
     end
+    
+    it "should not prune root_path directory when destroying file without directory prefix in path" do
+      uid = @data_store.store(@temp_object, :path => 'mate.png')
+      @data_store.destroy(uid)
+      @data_store.root_path.should be_an_empty_directory
+    end
 
     it "should raise an error if the data doesn't exist on destroy" do
       uid = @data_store.store(@temp_object)


### PR DESCRIPTION
e.g. 'image.jpg' instead of '123/456/78/image.jpg' - previously an invalid argument exception was being raised when purging empty directories.
