### PR TITLE
Allow mongodatastore to connect to mongo replica

### DIFF
--- a/lib/dragonfly/data_storage/mongo_data_store.rb
+++ b/lib/dragonfly/data_storage/mongo_data_store.rb
@@ -8,6 +8,8 @@ module Dragonfly
       include Serializer
 
       configurable_attr :host
+      configurable_attr :hosts
+      configurable_attr :mongo_connection_options
       configurable_attr :port
       configurable_attr :database, 'dragonfly'
       configurable_attr :username
@@ -21,6 +23,8 @@ module Dragonfly
 
       def initialize(opts={})
         self.host = opts[:host]
+        self.hosts = opts[:hosts]
+        self.mongo_connection_options = opts[:mongo_connection_options] || {}
         self.port = opts[:port]
         self.database = opts[:database] if opts[:database]
         self.username = opts[:username]
@@ -60,7 +64,11 @@ module Dragonfly
       end
 
       def connection
-        @connection ||= Mongo::Connection.new(host, port)
+        if hosts
+          @connection ||= Mongo::ReplSetConnection.new(hosts, mongo_connection_options)
+        else
+          @connection ||= Mongo::Connection.new(host, port, mongo_connection_options)
+        end
       end
 
       def db

--- a/spec/dragonfly/data_storage/mongo_data_store_spec.rb
+++ b/spec/dragonfly/data_storage/mongo_data_store_spec.rb
@@ -16,6 +16,15 @@ describe Dragonfly::DataStorage::MongoDataStore do
 
   it_should_behave_like 'data_store'
 
+  describe "contecting to a replica set" do
+    it "should initiate a replica set connection if hosts is set" do
+      @data_store.hosts = ['1.2.3.4:27017', '1.2.3.4:27017']
+      @data_store.mongo_connection_options = {:name => 'testingset'}
+      Mongo::ReplSetConnection.should_receive(:new).with(['1.2.3.4:27017', '1.2.3.4:27017'], :name => 'testingset')
+      @data_store.connection
+    end
+  end
+  
   describe "authenticating" do
     before(:each) do
       @temp_object = Dragonfly::TempObject.new('Feijão verde')


### PR DESCRIPTION
This also allows passing arbitrary connection options to the mongo driver.

the mongo driver changed how the replica set seeds are passed between 1.5.2 and 1.6.1. With 1.5 you'd do 

```
Mongo::ReplSetConnection.new(['host1', 27017], ['host2', 27017], {:some_option => true})
```

(ie a variable number of arguments)

with 1.6 you do

```
Mongo::ReplSetConnection.new(['host1:27017', 'host2:27017'], {:some_option => true})
```

This patch only handles the setup 1.6 uses. I could look at extending it to support 1.5 too if that is of interest
