### PR TITLE
Fix for define_macro_on_include

### DIFF
--- a/lib/dragonfly/app.rb
+++ b/lib/dragonfly/app.rb
@@ -141,12 +141,12 @@ module Dragonfly
       app = self
       name = self.name
       (class << mod; self; end).class_eval do
-        alias_method "included_without_dragonfly_#{name}", :included
-        define_method "included_with_dragonfly_#{name}" do |mod|
-          send "included_without_dragonfly_#{name}", mod
+        alias_method "included_without_dragonfly_#{name}_#{macro_name}", :included
+        define_method "included_with_dragonfly_#{name}_#{macro_name}" do |mod|
+          send "included_without_dragonfly_#{name}_#{macro_name}", mod
           app.define_macro(mod, macro_name)
         end
-        alias_method :included, "included_with_dragonfly_#{name}"
+        alias_method :included, "included_with_dragonfly_#{name}_#{macro_name}"
       end
     end
     


### PR DESCRIPTION
I am attempting to use dragonfly with MongoMapper. Following the Mongoid playbook since they are similar. My initializer is:

```
require 'dragonfly/rails/images'

app = Dragonfly[:images]

app.datastore = Dragonfly::DataStorage::MongoDataStore.new

app.define_macro_on_include MongoMapper::Document, :image_accessor
app.define_macro_on_include MongoMapper::Document, :file_accessor
app.define_macro_on_include MongoMapper::EmbeddedDocument, :image_accessor
app.define_macro_on_include MongoMapper::EmbeddedDocument, :file_accessor
```

I am defining both the "image_accessor" and "file_accessor" like the default AR implementation because I think it makes the model code clearer. But when I tried to load my model I got a stack overflow error.

Seems to be caused by the alias method chain which is being defined the same for both calls to define_macro_on_include. This patch adjusts the naming to include the macro name as well which has removed the error for me.
