### PR TITLE
Use explicit character encoding for uid generated by data store.

### DIFF
--- a/lib/dragonfly/data_storage/couch_data_store.rb
+++ b/lib/dragonfly/data_storage/couch_data_store.rb
@@ -29,7 +29,7 @@ module Dragonfly
           doc = CouchRest::Document.new(:meta => marshal_encode(temp_object.meta))
           response = db.save_doc(doc)
           doc.put_attachment(name, f.dup, :content_type => content_type)
-          form_uid(response['id'], name)
+          form_uid(response['id'], name).encode!
         end
       rescue RuntimeError => e
         raise UnableToStore, "#{e} - #{temp_object.inspect}"

--- a/lib/dragonfly/data_storage/file_data_store.rb
+++ b/lib/dragonfly/data_storage/file_data_store.rb
@@ -33,7 +33,7 @@ module Dragonfly
           raise UnableToStore, e.message
         end
 
-        relative(path)
+        relative(path).encode!
       end
 
       def retrieve(relative_path)

--- a/lib/dragonfly/data_storage/mongo_data_store.rb
+++ b/lib/dragonfly/data_storage/mongo_data_store.rb
@@ -39,7 +39,7 @@ module Dragonfly
         temp_object.file do |f|
           mongo_id = grid.put(f, :content_type => content_type,
                                  :metadata => marshal_encode(temp_object.meta))
-          mongo_id.to_s
+          mongo_id.to_s.encode!
         end
       end
 

--- a/lib/dragonfly/data_storage/s3data_store.rb
+++ b/lib/dragonfly/data_storage/s3data_store.rb
@@ -54,7 +54,7 @@ module Dragonfly
           end
         end
         
-        uid
+        uid.encode!
       end
 
       def retrieve(uid)

--- a/spec/dragonfly/data_storage/shared_data_store_examples.rb
+++ b/spec/dragonfly/data_storage/shared_data_store_examples.rb
@@ -22,6 +22,23 @@ shared_examples_for "data_store" do
     it "should allow for passing in options as a second argument" do
       @data_store.store(@temp_object, :some => :option)
     end
+
+    context "ruby 1.9", :ruby_version => "1.9" do
+      it "should return uid with appropriate character encoding because this affects the url of a job" do
+        stored_encoding = ::Encoding.default_internal
+        begin
+          ["UTF-8", "US-ASCII", "ISO-8859-1", "Shift_JIS", "EUC-JP", "Windows-31J", "EUC-JP"].each do |name|
+            encoding = ::Encoding.find(name)
+            ::Encoding.default_internal = encoding
+            uid = @data_store.store(Dragonfly::TempObject.new('asdf'))
+            uid.encoding.should == encoding
+          end
+        ensure
+          ::Encoding.default_internal = stored_encoding
+        end
+      end
+    end
+
   end
 
   describe "retrieve" do


### PR DESCRIPTION
Background:
ruby 1.9
Encoding.default_internal and Encoding.default_external set to 'UTF-8' 

Migrating from Ruby 1.8.7 to ruby 1.9.3 and running test suite i got several failures related to character encoding.

One failure was thrown by comparison of urls generated by Dragonfly.

Test case (integration test with capybara):
- Create a couple of model objects with images.
- Display list of images on the page.
- Verify image urls of objects created are present on the page.

Last step failed because image url of newly created object and image url of object loaded from database were different.

Looking deeper i found that uid of just created temp_object had 'US-ASCII' encoding but when it was saved to database as 'image_uid' and loaded back it got 'UTF-8' encoding.
And marshaling of equal strings with different encoding produces different results.

Discovering reasons why new uid has 'US-ASCII' encoding i found that is a Ruby behaviour.
Fixnum.to_s.encoding always return 'US-ASCII' for example, that leads BSON::ObjectID.to_s.encoding equal 'US-ASCII'. I guess Fixnum.to_s does not use Encoding.default_internal for performance or historical reasons. Anyway as different data stores can use different approaches of generation uids it's better to make them return value with specified encoding.  

So I updated .store method to return value encoded with Encoding.default_internal . May be this should be default_external instead, but they rarely differ.  
