### PR TITLE
MongoDataStore fix

### DIFF
--- a/lib/dragonfly/data_storage/mongo_data_store.rb
+++ b/lib/dragonfly/data_storage/mongo_data_store.rb
@@ -88,7 +88,7 @@ module Dragonfly
       end
 
       def bson_id(uid)
-        OBJECT_ID.from_string(uid)
+        uid.is_a?(String) ? OBJECT_ID.from_string(uid) : uid
       end
 
     end


### PR DESCRIPTION
If the +uid+ is already BSON::ObjectId, the +.from_string+ conversion in the +bson_id+ method is not required and should not be enforced (otherwise it throws an error and the file is not retrieved from GridFS).
