### PR TITLE
More robust URL signing

### DIFF
--- a/lib/dragonfly/server.rb
+++ b/lib/dragonfly/server.rb
@@ -34,7 +34,7 @@ module Dragonfly
       elsif (params = url_mapper.params_for(env["PATH_INFO"], env["QUERY_STRING"])) && params['job']
         job = Job.deserialize(params['job'], app)
         validate_job!(job)
-        job.validate_sha!(params['sha']) if protect_from_dos_attacks
+        job.validate_sha! if protect_from_dos_attacks
         response = Response.new(job, env)
         catch(:halt) do
           if before_serve_callback && response.will_be_served?
@@ -61,8 +61,7 @@ module Dragonfly
       opts = opts.dup
       host = opts.delete(:host) || url_host
       params = stringify_keys(opts)
-      params['job'] = job.serialize
-      params['sha'] = job.sha if protect_from_dos_attacks
+      params['job'] = job.serialize(protect_from_dos_attacks)
       url = url_mapper.url_for(params)
       "#{host}#{url}"
     end

--- a/spec/functional/model_urls_spec.rb
+++ b/spec/functional/model_urls_spec.rb
@@ -92,14 +92,6 @@ describe "model urls" do
     item.preview_image.encode(:bum).url.should =~ %r{^/media/\w+\.bum$}
   end
   
-  it "should work as normal with dos protection" do
-    @app.server.protect_from_dos_attacks = true
-    @item.preview_image = new_tempfile
-    @item.save!
-    item = Item.find(@item.id)
-    item.preview_image.url.should =~ %r{^/media/\w+/hello\.txt\?sha=\w+$}
-  end
-  
   it "should allow configuring the url" do
     @app.configure do |c|
       c.url_format = '/img/:job'


### PR DESCRIPTION
I love Dragonfly, but it's unusable if you have any CDNs or public proxies that do not use query strings. Specifically, Amazon's Cloudfront CDN does not pass query strings through to the origin server, and does not vary the content based on the query string.

To that end, I've rewritten the image signing so that the signature is simply a job step and is thus a part of the base64-encoded portion of the URL. This step is excluded when computing the signature, and `validate_sha!` looks for a Sig step and compares its first parameter to the job signature.

Specs have been updated accordingly, and pass.
