### PR TITLE
Change get_bucket to get_bucket_location

### DIFF
--- a/lib/dragonfly/data_storage/s3data_store.rb
+++ b/lib/dragonfly/data_storage/s3data_store.rb
@@ -108,7 +108,7 @@ module Dragonfly
       end
 
       def bucket_exists?
-        rescuing_socket_errors{ storage.get_bucket(bucket_name) }
+        rescuing_socket_errors{ storage.get_bucket_location(bucket_name) }
         true
       rescue Excon::Errors::NotFound => e
         false


### PR DESCRIPTION
I could be wrong, but using "get_bucket" seems inefficient as it will return a list of all of the objects in the bucket. Using "get_bucket_location" seems better as it will return just the location information of buckets that exist.
