### PR TITLE
sub_folder option for S3 data store

### DIFF
--- a/lib/dragonfly/data_storage/s3data_store.rb
+++ b/lib/dragonfly/data_storage/s3data_store.rb
@@ -10,6 +10,7 @@ module Dragonfly
 
       configurable_attr :bucket_name
       configurable_attr :access_key_id
+      configurable_attr :sub_folder
       configurable_attr :secret_access_key
       configurable_attr :region
       configurable_attr :use_filesystem, true
@@ -38,12 +39,12 @@ module Dragonfly
       def store(temp_object, opts={})
         ensure_configured
         ensure_bucket_initialized
-        
+
         headers = opts[:headers] || {}
         mime_type = opts[:mime_type] || opts[:content_type]
         headers['Content-Type'] = mime_type if mime_type
         uid = opts[:path] || generate_uid(temp_object.name || 'file')
-        
+
         rescuing_socket_errors do
           if use_filesystem
             temp_object.file do |f|
@@ -53,7 +54,7 @@ module Dragonfly
             storage.put_object(bucket_name, uid, temp_object.data, full_storage_headers(headers, temp_object.meta))
           end
         end
-        
+
         uid
       end
 
@@ -139,7 +140,8 @@ module Dragonfly
       end
 
       def generate_uid(name)
-        "#{Time.now.strftime '%Y/%m/%d/%H/%M/%S'}/#{rand(1000)}/#{name.gsub(/[^\w.]+/, '_')}"
+        uid = "#{Time.now.strftime '%Y/%m/%d/%H/%M/%S'}/#{rand(1000)}/#{name.gsub(/[^\w.]+/, '_')}"
+        sub_folder ? "#{sub_folder}/#{uid}" : uid
       end
 
       def full_storage_headers(headers, meta)


### PR DESCRIPTION
Hi there -- due to various configuration and other situations beyond our control we need to use "sub-folders" in our S3 buckets. At the moment, dragonfly will calculate the UID based on the current time and a random value, then put that directly into the bucket. Supplying a bucket name as "bucket_name/sub_folder" generates some error conditions, so the solution is to add an extra configuration option in order to supply a sub_folder "prefix" that will be appended to the UID if it was specified.

This is a really simple patch/approach. Please let me know if this is the right way to attack this problem, and if I should do anything else with the patch.

Thanks!
