### PR TITLE
to use b64_data method via accessor

### DIFF
--- a/lib/dragonfly/active_model_extensions/attachment.rb
+++ b/lib/dragonfly/active_model_extensions/attachment.rb
@@ -11,7 +11,7 @@ module Dragonfly
 
       extend Forwardable
       def_delegators :job,
-        :data, :to_file, :file, :tempfile, :path,
+        :data, :b64_data, :to_file, :file, :tempfile, :path,
         :process, :encode, :analyse,
         :meta, :meta=,
         :name, :size,


### PR DESCRIPTION
just little change.

I want to write code like this:
  <%= image_tag @user.avater_image.b64_data %>

regards,
