### PR TITLE
Provide Boolean query method for attribute.

### DIFF
--- a/lib/dragonfly/active_model_extensions/class_methods.rb
+++ b/lib/dragonfly/active_model_extensions/class_methods.rb
@@ -27,6 +27,10 @@ module Dragonfly
               dragonfly_attachments[attribute].to_value
             end
 
+            define_method "#{attribute}?" do
+              send "#{attribute}_uid?"
+            end
+
             # Define the URL setter
             define_method "#{attribute}_url=" do |url|
               unless url.blank?


### PR DESCRIPTION
I've been using Dragonfly for years (after being a file_column, then paperclip refugee). It is exactly what I need. I finally got tired of typing the _uid part of my conditional tests. I.E.

```
<%= image_tag obj.image.thumb('200x200').url if obj.image_uid? %>
```

With this patch it is now:

```
<%= image_tag obj.image.thumb('200x200').url if obj.image? %>
```

Not a big change but helps make it just a bit more seemless. :smile: 
