### PR TITLE
Allow fallback to legacy urls to be turned off

### DIFF
--- a/lib/dragonfly/app.rb
+++ b/lib/dragonfly/app.rb
@@ -52,6 +52,7 @@ module Dragonfly
     configurable_attr :trust_file_extensions, true
     configurable_attr :content_disposition
     configurable_attr :content_filename, Dragonfly::Response::DEFAULT_FILENAME
+    configurable_attr :allow_legacy_urls, true
 
     attr_reader :analyser
     attr_reader :processor

--- a/lib/dragonfly/job.rb
+++ b/lib/dragonfly/job.rb
@@ -175,7 +175,11 @@ module Dragonfly
         array = begin
           Serializer.json_decode(string)
         rescue Serializer::BadString
-          Serializer.marshal_decode(string) # legacy strings
+          if app.allow_legacy_urls
+            Serializer.marshal_decode(string) # legacy strings
+          else
+            raise
+          end
         end
         from_a(array, app)
       end

--- a/spec/dragonfly/job_spec.rb
+++ b/spec/dragonfly/job_spec.rb
@@ -548,10 +548,20 @@ describe Dragonfly::Job do
       job = Dragonfly::Job.deserialize("W1siZiIsInNvbWVfdWlkIl1d", @app)
       job.fetch_step.uid.should == 'some_uid'
     end
-    it "works with marshal encoded strings (deprecated)" do
-      job = Dragonfly::Job.deserialize("BAhbBlsHSSIGZgY6BkVUSSINc29tZV91aWQGOwBU", @app)
-      job.fetch_step.uid.should == 'some_uid'
+
+    context 'legacy urls are enabled' do
+      it "works with marshal encoded strings (deprecated)" do
+        job = Dragonfly::Job.deserialize("BAhbBlsHSSIGZgY6BkVUSSINc29tZV91aWQGOwBU", @app)
+        job.fetch_step.uid.should == 'some_uid'
+      end
     end
+
+    context 'legacy urls are disabled' do
+      it "rejects marshal encoded strings " do
+        @app.allow_legacy_urls = false
+        expect {Dragonfly::Job.deserialize("BAhbBlsHSSIGZgY6BkVUSSINc29tZV91aWQGOwBU", @app)}.to raise_error(Dragonfly::Serializer::BadString)
+      end
+    end    
   end
 
   describe "to_app" do


### PR DESCRIPTION
As discussed on mailing list, the ability to opt out of even attempting to parse the old marshal format
