### PR TITLE
Change source from :rubygems to https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "rack"
 gem "multi_json", "~> 1.0"


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.
