### PR TITLE
Job#fetch_url supports URLs with non-english characters

### DIFF
--- a/lib/dragonfly/job.rb
+++ b/lib/dragonfly/job.rb
@@ -131,7 +131,7 @@ module Dragonfly
         job.url_attrs[:name] = filename
       end
       def url
-        @url ||= (args.first[%r<^\w+://>] ? args.first : "http://#{args.first}")
+        @url ||= URI.escape((args.first[%r<^\w+://>] ? args.first : "http://#{args.first}"))
       end
       def path
         @path ||= URI.parse(url).path

--- a/spec/dragonfly/job_spec.rb
+++ b/spec/dragonfly/job_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'spec_helper'
 
 # Matchers
@@ -162,6 +163,7 @@ describe Dragonfly::Job do
       before(:each) do
         stub_request(:get, %r{http://some\.place\.com/.*}).to_return(:body => 'result!')
         stub_request(:get, 'https://some.place.com').to_return(:body => 'secure result!')
+        stub_request(:get, 'http://some.place.com/tilde/niños/emphasis/después').to_return(:body => 'still a valid URL!')
       end
 
       it {
@@ -193,7 +195,12 @@ describe Dragonfly::Job do
         @job.fetch_url!('some.place.com/dung.beetle')
         @job.url_attrs.should == {:name =>'dung.beetle'}
       end
-
+      
+      it 'should work with non-English URLs' do
+        @job.fetch_url!('http://some.place.com/tilde/niños/emphasis/después')
+        @job.data.should == 'still a valid URL!'
+      end
+      
       ["some.place.com", "some.place.com/", "some.place.com/eggs/"].each do |url|
         it "should not set the name if there isn't one, e.g. #{url}" do
           @job.fetch_url!(url)


### PR DESCRIPTION
## Before

Job#fetch_url was blowing up with a URI::InvalidURIError exception on URLs with non-english chars such as `http://static.bootic.net/167/original/69806-diseños-portada.jpg`
## Fix

Dragonfly::Job::FetchUrl makes sure to `URI.escape` its URL before parsing it and opening it, so non-english URLs work.
