### PR TITLE
Add support for specifying response headers in S3 data store

### DIFF
--- a/extra_docs/DataStorage.md
+++ b/extra_docs/DataStorage.md
@@ -111,6 +111,10 @@ or with a custom host:
 
     my_model.attachment.remote_url(:host => 'custom.domain')   # also configurable for all urls with 'url_host'
 
+or with a custom reponse header:
+
+    my_model.attachment.remote_url(:query => {"response-content-disposition" => "attachment; filename=Custom Filename.jpg"}, :expires => 3.days.from_now)
+
 Extra options you can use on store are `:path` and `:headers`
 
     app.store("SOME CONTENT", :path => 'some/path.txt', :headers => {'x-amz-acl' => 'public-read-write'})

--- a/lib/dragonfly/data_storage/s3data_store.rb
+++ b/lib/dragonfly/data_storage/s3data_store.rb
@@ -77,11 +77,13 @@ module Dragonfly
       end
 
       def url_for(uid, opts={})
-        if opts && opts[:expires]
+        if opts && (opts[:expires] || opts[:query])
+          raise ArgumentError.new("When passing the :query option to url_for you need to pass the :expires option as well") if opts[:expires].nil?
+          query_opts = opts[:query] ? {:query => opts[:query]} : {}
           if storage.respond_to?(:get_object_https_url) # fog's get_object_url is deprecated (aug 2011)
-            storage.get_object_https_url(bucket_name, uid, opts[:expires])
+            storage.get_object_https_url(bucket_name, uid, opts[:expires], query_opts)
           else
-            storage.get_object_url(bucket_name, uid, opts[:expires])
+            storage.get_object_url(bucket_name, uid, opts[:expires], query_opts)
           end
         else
           scheme = opts[:scheme] || url_scheme

--- a/spec/dragonfly/data_storage/s3_data_store_spec.rb
+++ b/spec/dragonfly/data_storage/s3_data_store_spec.rb
@@ -253,6 +253,17 @@ describe Dragonfly::DataStorage::S3DataStore do
         %r{^https://#{BUCKET_NAME}\.#{@data_store.domain}/some/path/on/s3\?AWSAccessKeyId=#{@data_store.access_key_id}&Signature=[\w%]+&Expires=1301476942$}
     end
 
+    it "should allow to give the query headers" do
+      @data_store.url_for(@uid, :expires => 1301476942, :query => {"response-content-disposition" => "attachment"}).should =~
+        %r{^https://#{BUCKET_NAME}\.#{@data_store.domain}/some/path/on/s3\?response-content-disposition=attachment&AWSAccessKeyId=#{@data_store.access_key_id}&Signature=[\w%]+&Expires=1301476942$}
+    end
+
+    it "should not allow to give query headers without expiry date" do
+      lambda {
+        @data_store.url_for(@uid, :query => {"response-content-disposition" => "attachment"})
+      }.should raise_error(ArgumentError)
+    end
+
     it "should allow for using https" do
       @data_store.url_for(@uid, :scheme => 'https').should == "https://#{BUCKET_NAME}.s3.amazonaws.com/some/path/on/s3"
     end


### PR DESCRIPTION
This allows to pass the `:query` option to `remote_url` when using the S3 data store to allow overwriting response headers like **Content-Disposition**. See updated extra_docs/DataStorage.md for an example.
