### PR TITLE
Replace rand function with more secure SecureRandom.hex

### DIFF
--- a/lib/rails/generators/dragonfly/dragonfly_generator.rb
+++ b/lib/rails/generators/dragonfly/dragonfly_generator.rb
@@ -8,7 +8,7 @@ class DragonflyGenerator < Rails::Generators::Base
   private
 
   def generate_secret
-    SecureRandom.hex(36)
+    SecureRandom.hex(32)
   end
 
   if RUBY_VERSION > "1.9"


### PR DESCRIPTION
Standard rand function can be predictable under some edge cases or if running the function multiple times.
