### PR TITLE
Try using @tempfile.size for TempObject#size

### DIFF
--- a/lib/dragonfly/core_ext/tempfile.rb
+++ b/lib/dragonfly/core_ext/tempfile.rb
@@ -1,0 +1,19 @@
+# Tempfile#size reports size of 0 after the tempfile has been
+# closed (without unlinking).  This happens because internal
+# @tmpfile is set to nil when the Tempfile is closed.
+# Alternatively @tmpname is set to nil when file is unlinked.
+
+if RUBY_VERSION < '1.9'
+  class Tempfile
+    def size
+      if @tmpfile
+        @tmpfile.flush
+        @tmpfile.stat.size
+      elsif @tmpname
+        File.size(@tmpname)
+      else
+        0
+      end
+    end
+  end
+end

--- a/lib/dragonfly/temp_object.rb
+++ b/lib/dragonfly/temp_object.rb
@@ -2,6 +2,7 @@ require 'stringio'
 require 'tempfile'
 require 'pathname'
 require 'fileutils'
+require 'dragonfly/core_ext/tempfile'
 
 module Dragonfly
 


### PR DESCRIPTION
If `@tempfile` is available, TempObject should be checking `@tempfile.size` instead of doing equivalent of `File.size(@tempfile.path)`.  In my particular case, `@tempfile` is actually a delegate to a remote (S3) object that separately (and lazily) pulls metadata (like size) and the file contents.  This change would prevent the file contents to be fetched to disk to just compute the file size.
