### PR TITLE
describe "identify" spec is failing due to a missing /n

### DIFF
--- a/spec/dragonfly/image_magick/plugin_spec.rb
+++ b/spec/dragonfly/image_magick/plugin_spec.rb
@@ -124,7 +124,7 @@ describe "a configured imagemagick app" do
   describe "identify" do
     it "gives the output of the command line" do
       image.identify.should =~ /280/
-      image.identify("-format %h").should == "355\n"
+      image.identify("-format %h").chomp.should == "355"
     end
   end
 


### PR DESCRIPTION
when running specs on jruby 1.7.10 the describe "identify" spec fails.  

The failure looks like this:

```
1) a configured imagemagick app identify gives the output of the command line
     Failure/Error: image.identify("-format %h").should == "355\n"
       expected: "355\n"
            got: "355" (using ==)
       Diff:
     # ./spec/dragonfly/image_magick/plugin_spec.rb:127:in `(root)'
```

The change simply chomps the resulting string.
