### PR TITLE
fix for temporary files without the original_filename attribute.

### DIFF
--- a/lib/dragonfly/temp_object.rb
+++ b/lib/dragonfly/temp_object.rb
@@ -47,6 +47,7 @@ module Dragonfly
         @data = obj
       elsif obj.is_a? Tempfile
         @tempfile = obj
+        @pathname = Pathname.new(obj.path) unless obj.respond_to?(:original_filename)
       elsif obj.is_a? File
         @pathname = Pathname.new(obj.path)
       elsif obj.is_a? Pathname

--- a/spec/dragonfly/temp_object_spec.rb
+++ b/spec/dragonfly/temp_object_spec.rb
@@ -244,6 +244,11 @@ describe Dragonfly::TempObject do
       temp_object.close
       File.exist?(path).should be_false
     end
+    
+    it "should define the original_filename attribute" do
+      temp_object = new_temp_object("HELLO")
+      temp_object.original_filename.should_not be_nil
+    end
   end
 
   describe "initializing from a file" do
@@ -379,10 +384,6 @@ describe Dragonfly::TempObject do
         'jimmy.page'
       end
       Dragonfly::TempObject.new(@obj).original_filename.should == 'jimmy.page'
-    end
-
-    it "should not set the name if the initial object doesn't respond to 'original filename'" do
-      Dragonfly::TempObject.new(@obj).original_filename.should be_nil
     end
 
     it "should set the name if the initial object is a file object" do


### PR DESCRIPTION
This PR fix a bug in the *TempObject*,  now one can use temporary files in conjunction with dragonfly without losing the original name of the temporary file, even if the `original_filename` attribute it's not defined.

how to reproduce the actual bug
ie:
```ruby
tmp_file = Tempfile.new(['hola', '.txt'], :encoding => 'ascii-8bit')
tmp_file.write(content)
img_uid = app.store(tmp_file)
puts img_uid
```
will output something similar to this:
*2014/03/18/11/47/41/506/file*

With this PR output should be something similar to:
*...path.../hola2843-84--0.txt*
