### PR TITLE
added the env so it can be accessed from the routed endpoint block

### DIFF
--- a/lib/dragonfly/routed_endpoint.rb
+++ b/lib/dragonfly/routed_endpoint.rb
@@ -14,7 +14,7 @@ module Dragonfly
 
     def call(env)
       params = Utils.symbolize_keys Rack::Request.new(env).params
-      value = @block.call(params.merge(routing_params(env)), @app)
+      value = @block.call(params.merge(routing_params(env)), @app, env)
       case value
       when nil then plain_response(404, "Not Found")
       when Job, Model::Attachment

--- a/spec/dragonfly/routed_endpoint_spec.rb
+++ b/spec/dragonfly/routed_endpoint_spec.rb
@@ -41,6 +41,11 @@ describe Dragonfly::RoutedEndpoint do
         response.body.should == 'wassup'
       end
 
+      it "should work with #{name} routing args and ENV parameters" do
+        response = response_for endpoint.call(env_for('/blah', key => {:uid => @uid}))
+        response.body.should == 'wassup'
+      end
+
     end
 
     it "should merge with query parameters" do
@@ -59,15 +64,16 @@ describe Dragonfly::RoutedEndpoint do
       Class.new do
         extend Dragonfly::Model
         dragonfly_accessor :image
-        attr_accessor :image_uid
+        dragonfly_accessor :secret
+        attr_accessor :image_uid, :secret_uid
       end
     }
     let (:model) {
       model_class.new
     }
     let (:endpoint) {
-      Dragonfly::RoutedEndpoint.new(app) {|params, app|
-        model.image
+      Dragonfly::RoutedEndpoint.new(app) {|params, app, env|
+        env['HTTP_X_TOKEN'] == "secret" ? model.secret : model.image
       }
     }
 
@@ -75,6 +81,18 @@ describe Dragonfly::RoutedEndpoint do
       model.image = "wassup"
       response = response_for endpoint.call(env_for('/blah', 'dragonfly.params' => {}))
       response.body.should == 'wassup'
+    end
+
+    it "acts like the job one with an invalid header token" do
+      model.image = "wassup"
+      response = response_for endpoint.call(env_for('/blah', { "HTTP_X_TOKEN" => "not-a-secret", 'dragonfly.params' => {} }))
+      response.body.should == 'wassup'
+    end
+
+    it "acts like the job one with a valid header token" do
+      model.secret = "test"
+      response = response_for endpoint.call(env_for('/blah', { "HTTP_X_TOKEN" => "secret", 'dragonfly.params' => {} }))
+      response.body.should == 'test'
     end
 
     it "returns 404 if nil is returned from the endpoint" do


### PR DESCRIPTION
Right now the routed endpoint provides access to the app and to the params. 

However, in many cases you may wish to have access to the full ENV so that you can look at the full HTTP headers. I specifically want this to look for API tokens I place in the header (as I want to keep them out of the url) but I can imagine other uses for this including special handling for if-modified-since, etags, etc.

In an ideal world I am not sure I'd make it the last variable provided to the block, but placing it there now should prevent this change from impacting existing apps.
