### PR TITLE
Remove default secret phrase, it should never be used

### DIFF
--- a/lib/dragonfly/app.rb
+++ b/lib/dragonfly/app.rb
@@ -259,7 +259,8 @@ module Dragonfly
     end
 
     def secret
-      @secret ||= 'secret yo'
+      @secret or raise "A secret is required to sign and verify Dragonfly job requests. " \
+                       "Use `secret '...'` or disable `protect_from_dos_attacks` in your config."
     end
     attr_writer :secret
 

--- a/spec/dragonfly/job_spec.rb
+++ b/spec/dragonfly/job_spec.rb
@@ -415,6 +415,11 @@ describe Dragonfly::Job do
     it "should be different for different jobs" do
       @app.fetch('figs').sha.should_not == @job.sha
     end
+
+    it "should raise error when secret is unspecified" do
+      @app.secret = nil
+      lambda{ @app.fetch('figs').sha }.should raise_error
+    end
   end
 
   describe "validate_sha!" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ end
 def test_app(name=nil)
   app = Dragonfly::App.instance(name)
   app.datastore = Dragonfly::MemoryDataStore.new
+  app.secret = "test secret"
   app
 end
 


### PR DESCRIPTION
I don't know why but Dragonfly has a default "secret". That means an app could be using this default secret to sign requests and its owner would be unaware that "sha" URL parameter does nothing. If an app does not need the protection (for whatever reason) it should disable it altogether.

I'm not sure I've added "raise" in the right place. Maybe it should go into "job.sha" or "job.validate_sha!".
