### PR TITLE
allow 'storage_options' method given by symbol to accept attachment object as argument

### DIFF
--- a/lib/dragonfly/model/attachment_class_methods.rb
+++ b/lib/dragonfly/model/attachment_class_methods.rb
@@ -126,7 +126,9 @@ module Dragonfly
           storage_options_specs.inject({}) do |opts, spec|
             options = case spec
             when Proc then model.instance_exec(attachment, &spec)
-            when Symbol then model.send(spec)
+            when Symbol
+              meth = model.method(spec)
+              (1 === meth.arity) ? meth.call(attachment) : meth.call
             else spec
             end
             opts.merge!(options)

--- a/spec/dragonfly/model/model_spec.rb
+++ b/spec/dragonfly/model/model_spec.rb
@@ -881,6 +881,14 @@ describe "models" do
       item.save!
     end
 
+    it 'should pass the attachment object if the method allows' do
+      set_storage_options :special_ops
+      item = @item_class.new :title => 'lump', :preview_image => 'hello'
+      def item.special_ops(a); {:egg => (a.data + title)}; end
+      @app.datastore.should_receive(:write).with(anything, hash_including(:egg => 'hellolump'))
+      item.save!
+    end
+
     it "should allow setting more than once" do
       @item_class.class_eval do
         dragonfly_accessor :preview_image do


### PR DESCRIPTION
allows 'storage_options' method given by symbol to accept attachment object as argument.