### PR TITLE
Remove incorrect sha parameter from error message

### DIFF
--- a/lib/dragonfly/server.rb
+++ b/lib/dragonfly/server.rb
@@ -68,7 +68,7 @@ module Dragonfly
     rescue Job::NoSHAGiven => e
       [400, {"Content-Type" => 'text/plain'}, ["You need to give a SHA parameter"]]
     rescue Job::IncorrectSHA => e
-      [400, {"Content-Type" => 'text/plain'}, ["The SHA parameter you gave (#{e}) is incorrect"]]
+      [400, {"Content-Type" => 'text/plain'}, ["The SHA parameter you gave is incorrect"]]
     rescue JobNotAllowed => e
       Dragonfly.warn(e.message)
       [403, {"Content-Type" => 'text/plain'}, ["Forbidden"]]


### PR DESCRIPTION
The output of the sha param is reported as an XSS vulnerability by some PCI scanners. If it's incorrect why should we trust it?
