### PR TITLE
Use Base64.urlsafe_encode64

### DIFF
--- a/lib/dragonfly/serializer.rb
+++ b/lib/dragonfly/serializer.rb
@@ -13,17 +13,23 @@ module Dragonfly
     extend self # So we can do Serializer.b64_encode, etc.
 
     def b64_encode(string)
-      Base64.encode64(string).tr("\n=",'')
+      Base64.urlsafe_encode64(string).tr('=','')
     end
 
     def b64_decode(string)
-      padding_length = string.length % 4
-      string = string.tr('~', '/')
-      Base64.decode64(string + '=' * padding_length)
+      padding_length = (-(string.length % 4)) % 4
+      string = string.tr('+','-').tr('~/','_')
+      Base64.urlsafe_decode64(string + '=' * padding_length)
+    rescue ArgumentError => e
+      raise BadString, "couldn't b64_decode string - got #{e}"
+    end
+
+    def urlunsafe_b64_encode(string)
+      Base64.encode64(string).tr("\n=",'')
     end
 
     def marshal_b64_encode(object)
-      b64_encode(Marshal.dump(object))
+      urlunsafe_b64_encode(Marshal.dump(object))
     end
 
     def marshal_b64_decode(string, opts={})

--- a/lib/dragonfly/url_mapper.rb
+++ b/lib/dragonfly/url_mapper.rb
@@ -54,10 +54,11 @@ module Dragonfly
     def init_segments(patterns)
       @segments = []
       url_format.scan(/([^\w_]):([\w_]+)/).each do |seperator, param|
+        param_sym = param.to_sym
         segments << Segment.new(
           param,
           seperator,
-          patterns[param.to_sym] || '[^\/\-\.]'
+          patterns[param_sym] || (param_sym == :job ? '[^\/\.]' : '[^\/\-\.]')
         )
       end
     end

--- a/spec/dragonfly/model/model_spec.rb
+++ b/spec/dragonfly/model/model_spec.rb
@@ -1127,7 +1127,7 @@ describe "models" do
       }.should raise_error(Dragonfly::Model::Attachment::BadAssignmentKey)
     end
 
-    [nil, "", "asdfsad"].each do |value|
+    [nil, ""].each do |value|
       it "should do nothing if assigned with #{value}" do
         @item.retained_preview_image = value
         @item.preview_image_uid.should be_nil

--- a/spec/dragonfly/serializer_spec.rb
+++ b/spec/dragonfly/serializer_spec.rb
@@ -13,10 +13,11 @@ describe Dragonfly::Serializer do
       '//..',
       'whats/up.egg.frog',
       '£ñçùí;',
-      '~'
+      '~',
+      '-umlaut_ö'
     ].each do |string|
-      it "should encode #{string.inspect} properly with no padding/line break" do
-        b64_encode(string).should_not =~ /\n|=/
+      it "should encode #{string.inspect} properly with no padding/line break or slash" do
+        b64_encode(string).should_not =~ /\n|=|\//
       end
       it "should correctly encode and decode #{string.inspect} to the same string" do
         str = b64_decode(b64_encode(string))
@@ -26,8 +27,9 @@ describe Dragonfly::Serializer do
     end
 
     describe "b64_decode" do
-      it "converts (deprecated) '~' characters to '/' characters" do
-        b64_decode('asdf~asdf').should == b64_decode('asdf/asdf')
+      it "converts (deprecated) '~' and '/' characters to '_' characters" do
+        b64_decode('LXVtbGF1dF~Dtg').should == b64_decode('LXVtbGF1dF/Dtg')
+        b64_decode('LXVtbGF1dF/Dtg').should == b64_decode('LXVtbGF1dF_Dtg')
       end
     end
 

--- a/spec/dragonfly/url_mapper_spec.rb
+++ b/spec/dragonfly/url_mapper_spec.rb
@@ -24,7 +24,7 @@ describe Dragonfly::UrlMapper do
   describe "url_regexp" do
     it "should return a regexp with non-greedy optional groups that include the preceding slash/dot/dash" do
       url_mapper = Dragonfly::UrlMapper.new('/media/:job/:basename-:size.:format')
-      url_mapper.url_regexp.should == %r{\A/media(/[^\/\-\.]+?)?(/[^\/\-\.]+?)?(\-[^\/\-\.]+?)?(\.[^\/\-\.]+?)?\z}
+      url_mapper.url_regexp.should == %r{\A/media(/[^\/\.]+?)?(/[^\/\-\.]+?)?(\-[^\/\-\.]+?)?(\.[^\/\-\.]+?)?\z}
     end
 
     it "should allow setting custom patterns in the url" do
@@ -98,6 +98,12 @@ describe Dragonfly::UrlMapper do
     it "should correctly url-unescape funny characters" do
       @url_mapper.params_for('/media/a%23c').should == {'job' => 'a#c'}
     end
+
+    it "should work with '-' character in url format" do
+      @url_mapper = Dragonfly::UrlMapper.new('/media/:job-:size.:format')
+      @url_mapper.params_for('/media/asdf-30x30.jpg').should == {'job' => 'asdf', 'size' => '30x30', 'format' => 'jpg'}
+      @url_mapper.params_for('/media/as-df-30x30.jpg').should == {'job' => 'as-df', 'size' => '30x30', 'format' => 'jpg'}
+    end
   end
 
   describe "matching urls with standard format /media/:job/:basename.:format" do
@@ -123,7 +129,7 @@ describe Dragonfly::UrlMapper do
       '/media/asdf/stuff/egg' => nil,
       '/media/asdf/stuff.dog.egg' => {'job' => 'asdf', 'basename' => 'stuff.dog', 'format' => 'egg'},
       '/media/asdf/s%3D2%2B-.d.e' => {'job' => 'asdf', 'basename' => 's=2+-.d', 'format' => 'e'},
-      '/media/asdf-40x40/stuff.egg' => nil,
+      '/media/asdf-40x40/stuff.egg' => {'job' => 'asdf-40x40', 'basename' => 'stuff', 'format' => 'egg'},
       '/media/a%23c' => {'job' => 'a#c', 'basename' => nil, 'format' => nil}
     }.each do |path, params|
 

--- a/spec/functional/urls_spec.rb
+++ b/spec/functional/urls_spec.rb
@@ -44,7 +44,7 @@ describe "urls" do
 
   it "works with potentially tricky url characters for the url" do
     url = app.fetch('uid []=~/+').url(:name => 'name []=~/+')
-    url.should =~ %r(^/[\w%]+/name%20%5B%5D%3D%7E%2F%2B$)
+    url.should =~ %r(^/[\w-]+/name%20%5B%5D%3D%7E%2F%2B$)
     job_should_match [["f", "uid []=~/+"]]
     response = request(app, url)
   end


### PR DESCRIPTION
This method complies with
»Base 64 Encoding with URL and Filename Safe Alphabet« in RFC 4648
see http://tools.ietf.org/html/rfc4648#page-7

# Bug
Ran into problems when a Job would serialize to a Base64 string
**containing a slash** (see https://github.com/janraasch/dragonfly/blob/645d6e74aab24386f6cdcdd2c2f6289431447c87/spec/dragonfly/serializer_spec.rb#L17), since apache does not allow slashes in an URI:

From our `var/log/apache2/error.log` log:

```bash
found %2f (encoded '/') in URI (decoded='/media/W1siZiIsInNhbGVzZm9yY2UvdXBsb2Fkcy9zb3VyY2VfZmlsZXMvMDA2TTAwMDAwMEFaRmxXSUFYLXVtbGF1dF/DpCAoMykuemlwIl1d/umlaut_\xc3\xa4.zip'), returning 404
```

# Breaking changes
Nope. Thanks to the proposed implementation of `Dragonfly::Serializer.b64_decode` (https://github.com/janraasch/dragonfly/blob/ac84591b03cab402daa0171345e06dcb08b4ad17/lib/dragonfly/serializer.rb#L19) and `Dragonfly::UrlMapper#init_segments` (https://github.com/janraasch/dragonfly/blob/ac84591b03cab402daa0171345e06dcb08b4ad17/lib/dragonfly/url_mapper.rb#L61) this should be backwards compatible with *urls* encoded with *urlunsafe* `Base64.encode64` and url formats using a `-` like `:job/:name-:size`.

What do you think?