### PR TITLE
Backport of regexp fixes and SHA improvements to 0.8.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source :rubygems
 # These gems are needed for development and testing
 group :development, :test, :cucumber do
   gem 'aws-s3'
-  gem 'capybara'
+  gem 'capybara', '~> 2.0.3' # later versions don't support Ruby 1.9.2
   gem 'cucumber'
   gem 'cucumber-rails'
   gem 'database_cleaner', '>= 0.5.0'

--- a/lib/dragonfly/job.rb
+++ b/lib/dragonfly/job.rb
@@ -256,7 +256,11 @@ module Dragonfly
     end
 
     def sha
-      Digest::SHA1.hexdigest("#{to_unique_s}#{app.secret}")[0...8]
+      unless app.secret
+        raise CannotGenerateSha, "A secret is required to sign and verify Dragonfly job requests. "\
+                                 "Use `secret '...'` or disable `protect_from_dos_attacks` in your config."
+      end
+      OpenSSL::HMAC.hexdigest('SHA256', app.secret, to_unique_s)[0,16]
     end
 
     def validate_sha!(sha)

--- a/lib/dragonfly/processing/image_magick_processor.rb
+++ b/lib/dragonfly/processing/image_magick_processor.rb
@@ -15,9 +15,9 @@ module Dragonfly
       }
       
       # Geometry string patterns
-      RESIZE_GEOMETRY         = /^\d*x\d*[><%^!]?$|^\d+@$/ # e.g. '300x200!'
-      CROPPED_RESIZE_GEOMETRY = /^(\d+)x(\d+)#(\w{1,2})?$/ # e.g. '20x50#ne'
-      CROP_GEOMETRY           = /^(\d+)x(\d+)([+-]\d+)?([+-]\d+)?(\w{1,2})?$/ # e.g. '30x30+10+10'
+      RESIZE_GEOMETRY         = /\A\d*x\d*[><%^!]?\z|\A\d+@\z/ # e.g. '300x200!'
+      CROPPED_RESIZE_GEOMETRY = /\A(\d+)x(\d+)#(\w{1,2})?\z/ # e.g. '20x50#ne'
+      CROP_GEOMETRY           = /\A(\d+)x(\d+)([+-]\d+)?([+-]\d+)?(\w{1,2})?\z/ # e.g. '30x30+10+10'
       THUMB_GEOMETRY = Regexp.union RESIZE_GEOMETRY, CROPPED_RESIZE_GEOMETRY, CROP_GEOMETRY
       
       include ImageMagickUtils
@@ -31,9 +31,9 @@ module Dragonfly
         height  = opts[:height]
         gravity = GRAVITIES[opts[:gravity]]
         x       = "#{opts[:x] || 0}"
-        x = '+' + x unless x[/^[+-]/]
+        x = '+' + x unless x[/\A[+-]/]
         y       = "#{opts[:y] || 0}"
-        y = '+' + y unless y[/^[+-]/]
+        y = '+' + y unless y[/\A[+-]/]
       
         convert(temp_object, "-crop #{width}x#{height}#{x}#{y}#{" -gravity #{gravity}" if gravity}")
       end

--- a/spec/dragonfly/job_spec.rb
+++ b/spec/dragonfly/job_spec.rb
@@ -630,7 +630,7 @@ describe Dragonfly::Job do
     end
     
     it "should be of the correct format" do
-      @job.sha.should =~ /^\w{8}$/
+      @job.sha.should =~ /^\w{16}$/
     end
     
     it "should be the same for the same job steps" do


### PR DESCRIPTION
I've backported 00bb02978e33417d72ddf573a61ee7c10b35d9aa and 9f5a83a6b2861c256861375e81859d5cbfdfca70 to address security issue OSVDB-110439.

Should e88afeceb036fe4d44f7c7787c7e988e1350c2dc also be backported, or is this PR sufficient?

Also, I pinned capybara to a version that supports Ruby 1.9.2.
