### PR TITLE
Timing of shell commands

### DIFF
--- a/lib/dragonfly/shell.rb
+++ b/lib/dragonfly/shell.rb
@@ -9,9 +9,13 @@ module Dragonfly
     class CommandFailed < RuntimeError; end
 
     def run(command, opts={})
-      command = escape_args(command) unless opts[:escape] == false
-      Dragonfly.debug("shell command: #{command}")
-      run_command(command)
+      Dragonfly.debug("shell command started: #{command}")
+      beginning_time = Time.now
+      result = run_command(command)
+      end_time = Time.now
+      time = (end_time - beginning_time) * 1000
+      Dragonfly.debug("shell command finished: #{time}ms")
+      result
     end
 
     def escape_args(args)


### PR DESCRIPTION
Simple way to time shell commands such as `identify` to be able to see their performance impact.

Example:

2015-01-12 15:35:59.362 [DEBUG] DRAGONFLY: shell command started: 'identify' ... ' (pid:10642)
2015-01-12 15:35:59.376 [DEBUG] DRAGONFLY: shell command finished: 13.68ms (pid:10642)

(I needed it to optimize some image migrations)