### PR TITLE
up minimum rack version. needed for Rack::Utils.escape_path

### DIFF
--- a/dragonfly.gemspec
+++ b/dragonfly.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     "README.md"
   ]
 
-  spec.add_runtime_dependency("rack", [">= 0"])
+  spec.add_runtime_dependency("rack", [">= 1.3.0"])
   spec.add_runtime_dependency("multi_json", ["~> 1.0"])
   spec.add_runtime_dependency("addressable", ["~> 2.3"])
 


### PR DESCRIPTION
Rack::Utils.escape_path is used in Dragonfly::Utils.uri_escape_segment, but is only available in rack v1.3+