### PR TITLE
properly escaped urls still get encoded with / sometimes, so should just...

### DIFF
--- a/lib/dragonfly/serializer.rb
+++ b/lib/dragonfly/serializer.rb
@@ -13,13 +13,11 @@ module Dragonfly
     extend self # So we can do Serializer.b64_encode, etc.
 
     def b64_encode(string)
-      Base64.encode64(string).tr("\n=",'')
+      Base64.urlsafe_encode64(string)
     end
 
     def b64_decode(string)
-      padding_length = string.length % 4
-      string = string.tr('~', '/')
-      Base64.decode64(string + '=' * padding_length)
+      Base64.urlsafe_decode64(string)
     end
 
     def marshal_b64_encode(object)


### PR DESCRIPTION
... use urlsafe base64 encoding

When using Dragonfly.app.fetch_url(...) these encoding methods still occasionally produce values with `/` in them which breaks the routing in my production environment.  `urlsafe_encode64` just does it correctly and also doesn't add `\n`.  I could be missing something here, but ALL of my images are working now!!