### PR TITLE
allow relative redirects to be followed

### DIFF
--- a/lib/dragonfly/job/fetch_url.rb
+++ b/lib/dragonfly/job/fetch_url.rb
@@ -55,7 +55,8 @@ module Dragonfly
         response = get(url)
         case response
         when Net::HTTPSuccess then response.body || ""
-        when Net::HTTPRedirection then get_following_redirects(response['location'], redirect_limit-1)
+        when Net::HTTPRedirection then
+          get_following_redirects(redirect_url(url, response['location']), redirect_limit-1)
         else
           response.error!
         end
@@ -94,6 +95,13 @@ module Dragonfly
         end
       end
 
+      def redirect_url(current_url, following_url)
+        redirect_url = URI.parse(following_url)
+        if redirect_url.relative?
+          redirect_url = URI::join(current_url, following_url)
+        end
+        redirect_url
+      end
     end
   end
 end

--- a/spec/dragonfly/job/fetch_url_spec.rb
+++ b/spec/dragonfly/job/fetch_url_spec.rb
@@ -134,6 +134,12 @@ describe Dragonfly::Job::FetchUrl do
         job.fetch_url('redirectme.com').apply
       }.to raise_error(Dragonfly::Job::FetchUrl::TooManyRedirects)
     end
+
+    it 'follows relative response ' do
+      stub_request(:get, "redirectme.com").to_return(:status => 302, :headers => {'Location' => 'relative-path.html'})
+      stub_request(:get, "redirectme.com/relative-path.html").to_return(:body => "OK!")
+      job.fetch_url('redirectme.com').data.should == 'OK!'
+    end
   end
 
   describe "data uris" do


### PR DESCRIPTION
I have encountered the following error message when I used `Dragonfly.app.fetch_url`:
`NoMethodError: undefined method`request_uri' for #<URI::Generic:0x00000005c45838 URL:relative-path.html>`
The problem occurs when a server returns HTTP redirect status code with **a relative path** to a currently used URL which is a valid behaviour according to RFC 7231 (source: http://stackoverflow.com/questions/8250259/is-a-302-redirect-to-relative-url-valid-or-invalid#answer-25643550)
I have reproduced it in a test and then I fixed it with a help of this site: http://shadow-file.blogspot.co.uk/2009/03/handling-http-redirection-in-ruby.html
