### PR TITLE
Handling edge case for TempObject#to_file

### DIFF
--- a/lib/dragonfly/temp_object.rb
+++ b/lib/dragonfly/temp_object.rb
@@ -131,12 +131,15 @@ module Dragonfly
       mode = opts[:mode] || 0644
       prepare_path(path) unless opts[:mkdirs] == false
       if @data
-        File.open(path, 'wb', mode){|f| f.write(@data) }
+        File.open(path, 'wb', mode) do |f|
+          f.write(@data)
+          File.new(path, 'rb')
+        end
       else
         FileUtils.cp(self.path, path)
         File.chmod(mode, path)
+        File.new(path, 'rb')
       end
-      File.new(path, 'rb')
     end
 
     def to_tempfile

--- a/spec/dragonfly/temp_object_spec.rb
+++ b/spec/dragonfly/temp_object_spec.rb
@@ -147,6 +147,9 @@ describe Dragonfly::TempObject do
           filename = 'tmp/gog/mcgee'
           expect{ @temp_object.to_file(filename, :mkdirs => false) }.to raise_error()
         end
+        it "should return a File object" do
+          @temp_object.to_file(@filename).should be_a(File)
+        end
       end
 
       describe "to_tempfile" do


### PR DESCRIPTION
Based on the following documentation (see below) that is consistent
from Ruby 1.9.1 and up, the following change accounts for a situation
in which I'm handling a large file.

The setup is as follows:

I have a 17MB file on AWS. I use Dragonfly's #to_file to make a local
copy of that file (see the below Ruby code). Through debugging, I see
that the `@data` instance variable is set. So the following code is
executed: `File.open(path, 'wb', mode){|f| f.write(@data) }`. From
there it appears as though the block executes but does not fully finish
before the `File.new(path, 'rb')` executes and throws an
`#<Errno::ENOENT: No such file or directory @ rb_sysopen>` exception.

I don't know if its a matter of the ensure portion of the `File.open`
block is completing asynchronously against the file system (i.e.
closing the file). However when I include the changes in this commit
things appear to work for my use case.

``` ruby
def to_file(path, opts={})
  mode = opts[:mode] || 0644
  prepare_path(path) unless opts[:mkdirs] == false
  if @data
    File.open(path, 'wb', mode){|f| f.write(@data) }
  else
    FileUtils.cp(self.path, path)
    File.chmod(mode, path)
  end
  File.new(path, 'rb')
end
```

Documentation

```
"The value of the block will be returned from File.open."
```
- http://ruby-doc.org/core-2.2.2/File.html#method-c-open
- http://ruby-doc.org/core-2.1.6/File.html#method-c-open
- http://ruby-doc.org/core-2.1.4/File.html#method-c-open
- http://ruby-doc.org/core-2.0.0/File.html#method-c-open
- http://ruby-doc.org/core-1.9.3/File.html#method-c-open
- http://ruby-doc.org/core-1.9.2/File.html#method-c-open
- http://ruby-doc.org/core-1.9.1/File.html#method-c-open
