### PR TITLE
Return X-Cascade header in response when job fetch fails to find file.

### DIFF
--- a/lib/dragonfly/response.rb
+++ b/lib/dragonfly/response.rb
@@ -26,7 +26,7 @@ module Dragonfly
         end
       rescue Job::Fetch::NotFound => e
         Dragonfly.warn(e.message)
-        [404, {"Content-Type" => "text/plain"}, ["Not found"]]
+        [404, {"Content-Type" => "text/plain", "X-Cascade" => "pass"}, ["Not found"]]
       rescue RuntimeError => e
         Dragonfly.warn("caught error - #{e.message}")
         [500, {"Content-Type" => "text/plain"}, ["Internal Server Error"]]


### PR DESCRIPTION
This allows multiple Dragonfly apps to attempt handling the file (e.g. in RefineryCMS, refinerycms-images, refinerycms-resources).

There is an existing failure in the specs (spec/dragonfly/image_magick/plugin_spec.rb:63) but this change doesn't affect them. Let me know if you need an extra spec to verify the behaviour.
