### PR TITLE
Compatibility with Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - "2.1"
   - "2.2"
   - "2.3.0"
+  - "2.4.0"
   - "jruby"
 script: bundle exec rspec spec
 before_install:

--- a/lib/dragonfly/temp_object.rb
+++ b/lib/dragonfly/temp_object.rb
@@ -84,6 +84,19 @@ module Dragonfly
       @data ||= file{|f| f.read }
     end
 
+    def tempfile
+      raise Closed, "can't read from tempfile as TempObject has been closed" if closed?
+      @tempfile ||= begin
+        case
+        when @data
+          @tempfile = Utils.new_tempfile(ext, @data)
+        when @pathname
+          @tempfile = copy_to_tempfile(@pathname.expand_path)
+        end
+        @tempfile
+      end
+    end
+
     def file(&block)
       f = tempfile.open
       tempfile.binmode
@@ -173,19 +186,6 @@ module Dragonfly
     end
 
     private
-
-    def tempfile
-      raise Closed, "can't read from tempfile as TempObject has been closed" if closed?
-      @tempfile ||= begin
-        case
-        when @data
-          @tempfile = Utils.new_tempfile(ext, @data)
-        when @pathname
-          @tempfile = copy_to_tempfile(@pathname.expand_path)
-        end
-        @tempfile
-      end
-    end
 
     def block_size
       8192


### PR DESCRIPTION
Fixes a warning outputted by Forwardable since forwarding to a private method is deprecated in Ruby 2.4:

```
~/dragonfly/lib/dragonfly/temp_object.rb:55:in `initialize': Dragonfly::Content#tempfile at ~/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/forwardable.rb:156 forwarding to private method Dragonfly::TempObject#tempfile
```

Also added Ruby 2.4.0 to Travis.