### PR TITLE
fix ruby 2.4.0 regression by not considering order of '.' and '..' nodes

### DIFF
--- a/lib/dragonfly/file_data_store.rb
+++ b/lib/dragonfly/file_data_store.rb
@@ -168,7 +168,7 @@ module Dragonfly
     end
 
     def directory_empty?(path)
-      Dir.entries(path) == ['.','..']
+      Dir.entries(path).sort == ['.','..'].sort
     end
 
     def root_path?(dir)

--- a/spec/support/simple_matchers.rb
+++ b/spec/support/simple_matchers.rb
@@ -9,7 +9,7 @@ end
 
 RSpec::Matchers.define :be_an_empty_directory do
   match do |given|
-    !!ENV['TRAVIS'] || (Dir.entries(given) == ['.','..'])
+    !!ENV['TRAVIS'] || (Dir.entries(given).sort == ['.','..'].sort)
   end
 end
 


### PR DESCRIPTION
...when checking for empty directory

As the subject says, there seem to be a regression in ruby 2.4.0 (or is it a os specific thing?). 

BTW: as of ruby 2.4.0 there's also a new `Dir.empty?`

