### PR TITLE
Allow :mime_type & :ext to be magic attributes

### DIFF
--- a/lib/dragonfly/model/attachment_class_methods.rb
+++ b/lib/dragonfly/model/attachment_class_methods.rb
@@ -91,7 +91,7 @@ module Dragonfly
 
         # Magic attributes
         def allowed_magic_attributes
-          app.analyser_methods + [:size, :name]
+          app.analyser_methods + [:size, :name, :mime_type, :ext]
         end
 
         def magic_attributes


### PR DESCRIPTION
This is simply to permit `*_mime_type` and `*_ext` attributes to be assigned from the magic attributes. Should cause no harm?

And why?
For example some audio players require mime-type to playback the file correctly in all browsers.