### PR TITLE
Monkey patch to get filename from headers

### DIFF
--- a/lib/dragonfly/job/fetch_url.rb
+++ b/lib/dragonfly/job/fetch_url.rb
@@ -44,6 +44,9 @@ module Dragonfly
           update_from_data_uri
         else
           response = get_following_redirects(url)
+          if _filename = response.header["content-disposition"].presence.try(:match, /filename="(.*)"/).try(:[], 1)
+            @filename = _filename
+          end
           job.content.update(response.body || "", 'name' => filename, 'mime_type' => response.content_type)
         end
       end


### PR DESCRIPTION
Dropbox put the filename in the headers. This patch retrieve the filename with the *_url= method