### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/dragonfly/model/class_methods.rb
+++ b/lib/dragonfly/model/class_methods.rb
@@ -86,7 +86,7 @@ module Dragonfly
             unless Utils.blank?(string)
               begin
                 dragonfly_attachments[attribute].retained_attrs = Serializer.json_b64_decode(string)
-              rescue Serializer::BadString => e
+              rescue Serializer::BadString
                 Dragonfly.warn("couldn't update attachment with serialized retained_#{attribute} string #{string.inspect}")
               end
             end

--- a/lib/dragonfly/routed_endpoint.rb
+++ b/lib/dragonfly/routed_endpoint.rb
@@ -24,9 +24,9 @@ module Dragonfly
         Dragonfly.warn("can't handle return value from routed endpoint: #{value.inspect}")
         plain_response(500, "Server Error")
       end
-    rescue Job::NoSHAGiven => e
+    rescue Job::NoSHAGiven
       plain_response(400, "You need to give a SHA parameter")
-    rescue Job::IncorrectSHA => e
+    rescue Job::IncorrectSHA
       plain_response(400, "The SHA parameter you gave is incorrect")
     end
 

--- a/lib/dragonfly/server.rb
+++ b/lib/dragonfly/server.rb
@@ -28,11 +28,11 @@ module Dragonfly
     attr_reader :url_format, :fetch_file_whitelist, :fetch_url_whitelist
 
     def add_to_fetch_file_whitelist(patterns)
-      fetch_file_whitelist.push *patterns
+      fetch_file_whitelist.push(*patterns)
     end
 
     def add_to_fetch_url_whitelist(patterns)
-      fetch_url_whitelist.push *patterns
+      fetch_url_whitelist.push(*patterns)
     end
 
     def url_format=(url_format)

--- a/lib/dragonfly/url_mapper.rb
+++ b/lib/dragonfly/url_mapper.rb
@@ -24,7 +24,7 @@ module Dragonfly
 
     def initialize(url_format)
       @url_format = url_format
-      raise BadUrlFormat, "bad url format #{url_format}" if url_format[/[\w_]:[\w_]/]
+      raise BadUrlFormat, "bad url format #{url_format}" if url_format[/[\w]:[\w]/]
       init_segments
       init_url_regexp
     end
@@ -43,7 +43,7 @@ module Dragonfly
     end
 
     def params_in_url
-      @params_in_url ||= url_format.scan(/\:[\w_]+/).map{|f| f.tr(':','') }
+      @params_in_url ||= url_format.scan(/\:[\w]+/).map{|f| f.tr(':','') }
     end
 
     def url_for(params)
@@ -51,7 +51,7 @@ module Dragonfly
       url = url_format.dup
       segments.each do |seg|
         value = params[seg.param]
-        value ? url.sub!(/:[\w_]+/, Utils.uri_escape_segment(value.to_s)) : url.sub!(/.:[\w_]+/, '')
+        value ? url.sub!(/:[\w]+/, Utils.uri_escape_segment(value.to_s)) : url.sub!(/.:[\w]+/, '')
         params.delete(seg.param)
       end
       url << "?#{Rack::Utils.build_query(params)}" if params.any?
@@ -62,7 +62,7 @@ module Dragonfly
 
     def init_segments
       @segments = []
-      url_format.scan(/([^\w_]):([\w_]+)/).each do |seperator, param|
+      url_format.scan(/([^\w]):([\w]+)/).each do |seperator, param|
         segments << Segment.new(
           param,
           seperator,
@@ -73,7 +73,7 @@ module Dragonfly
 
     def init_url_regexp
       i = -1
-      regexp_string = url_format.gsub(/[^\w_]:[\w_]+/) do
+      regexp_string = url_format.gsub(/[^\w]:[\w]+/) do
         i += 1
         segments[i].regexp_string
       end


### PR DESCRIPTION
This fixes following warnings.

```
/lib/dragonfly/server.rb:31: warning: `*' interpreted as argument prefix
/lib/dragonfly/server.rb:35: warning: `*' interpreted as argument prefix

/lib/dragonfly/url_mapper.rb:27: warning: character class has duplicated range: /[\w_]:[\w_]/
/lib/dragonfly/url_mapper.rb:46: warning: character class has duplicated range: /\:[\w_]+/
/lib/dragonfly/url_mapper.rb:54: warning: character class has duplicated range: /:[\w_]+/
/lib/dragonfly/url_mapper.rb:54: warning: character class has duplicated range: /.:[\w_]+/
/lib/dragonfly/url_mapper.rb:65: warning: character class has duplicated range: /([^\w_]):([\w_]+)/
/lib/dragonfly/url_mapper.rb:76: warning: character class has duplicated range: /[^\w_]:[\w_]+/

/lib/dragonfly/routed_endpoint.rb:27: warning: assigned but unused variable - e
/lib/dragonfly/routed_endpoint.rb:29: warning: assigned but unused variable - e

/lib/dragonfly/model/class_methods.rb:89: warning: assigned but unused variable - e
```