### PR TITLE
Destroy model attachments on after_destroy callback

### DIFF
--- a/lib/dragonfly/model/class_methods.rb
+++ b/lib/dragonfly/model/class_methods.rb
@@ -30,7 +30,7 @@ module Dragonfly
 
         # Add callbacks
         before_save :save_dragonfly_attachments if respond_to?(:before_save)
-        before_destroy :destroy_dragonfly_attachments if respond_to?(:before_destroy)
+        after_destroy :destroy_dragonfly_attachments if respond_to?(:after_destroy)
 
         # Register the new attribute
         dragonfly_attachment_classes << new_dragonfly_attachment_class(attribute, app, config_block)


### PR DESCRIPTION
As referenced on #477, this pull request moves the logic of removing attachments from a _before_destroy_ callback into an _after_destroy_ callback, fixing a bug that causes removing the model attachements even if the model was not destroyed completely.