### PR TITLE
Single caret as resize argument

### DIFF
--- a/lib/dragonfly/image_magick/processors/thumb.rb
+++ b/lib/dragonfly/image_magick/processors/thumb.rb
@@ -69,7 +69,7 @@ module Dragonfly
 
         def resize_and_crop_args(width, height, gravity)
           gravity = GRAVITIES[gravity || 'c']
-          "-resize #{width}x#{height}^^ -gravity #{gravity} -crop #{width}x#{height}+0+0 +repage"
+          "-resize #{width}x#{height}^ -gravity #{gravity} -crop #{width}x#{height}+0+0 +repage"
         end
 
       end


### PR DESCRIPTION
We do not need double `^^` in resize to escape single caret in Windows cmd since all arguments escaped via quotes `"150x100^"`.

https://github.com/markevans/dragonfly/blob/364a6eb4615d2f8618bf0dd4473dde91ab194660/lib/dragonfly/shell.rb#L17-L26