### PR TITLE
runtime dependencies cannot depend on RUBY_VERSION

### DIFF
--- a/dragonfly.gemspec
+++ b/dragonfly.gemspec
@@ -21,24 +21,15 @@ Gem::Specification.new do |spec|
     "README.md"
   ]
 
-  # Rack 2.0 only works with ruby >= 2.2.2
-  if RUBY_VERSION < "2.2.2"
-    rack_version = "~> 1.3"
-    activemodel_version = "~> 4.2"
-  else
-    rack_version = ">= 1.3"
-    activemodel_version = nil
-  end
-
   # Runtime dependencies
-  spec.add_runtime_dependency("rack", rack_version)
+  spec.add_runtime_dependency("rack", ">= 1.3")
   spec.add_runtime_dependency("multi_json", "~> 1.0")
   spec.add_runtime_dependency("addressable", "~> 2.3")
 
   # Development dependencies
   spec.add_development_dependency("rspec", "~> 2.5")
   spec.add_development_dependency("webmock")
-  spec.add_development_dependency("activemodel", activemodel_version)
+  spec.add_development_dependency("activemodel")
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency("jruby-openssl")
   end


### PR DESCRIPTION
The gemspec is evaluated when the gem is built and baked into the metadata and is not evaluated at install time. Any logic around RUBY_VERSION is applied based on the ruby that built the gem, not the
end user's ruby as is desired.

This is fairly common and has been known to cause issues on other gems, see https://github.com/AuthorizeNet/sdk-ruby/pull/116
