### PR TITLE
Support Callable `url_host`

### DIFF
--- a/spec/dragonfly/server_spec.rb
+++ b/spec/dragonfly/server_spec.rb
@@ -263,6 +263,13 @@ describe Dragonfly::Server do
         server.url_host = 'http://some.server:4000'
         server.url_for(job, :host => 'https://smeedy').should == "https://smeedy/#{job.serialize}"
       end
+
+      it "should support callable host objects" do
+        server.url_host = proc { |_| "https://#{SecureRandom.random_number}.example.com" }
+
+        server.url_for(job).should =~ /example\.com/
+        server.url_for(job).should_not =~ /Proc/
+      end
     end
 
     describe "path_prefix" do


### PR DESCRIPTION
We set `Rails.configuration.asset_host` as a callable object since it
can depend on the current state of the application. This causes a String
like `"<Proc:0x001>"` to appear in the URLs where the job name should
be, because `#url_for` doesn't run `#call` on the `#url_host` prior to
returning a String. The `Dragonfly::Server#url_for` reader method has
been updated to run `#call` on the `url_host` if the object responds to
it.