### PR TITLE
Fix url parsing in Dragonfly::Job::FetchUrl

### DIFF
--- a/lib/dragonfly/job/fetch_url.rb
+++ b/lib/dragonfly/job/fetch_url.rb
@@ -91,7 +91,7 @@ module Dragonfly
       end
 
       def parse_url(url)
-        URI.parse(url)
+        URI.parse(url.to_s)
       rescue URI::InvalidURIError
         begin
           encoded_uri = Addressable::URI.parse(url).normalize.to_s


### PR DESCRIPTION
This fixes an edge case when retreiving files behind certain redirects. `redirect_url` returns a URI object which is passed to `parse_url`, which calls `URI.parse(url)`. This crashes when url is not a string, but that crash is caught and url is run through `Addressable::URI.parse(url)`. This removes percent-encoding from the url, e.g. `http://example.com?q=http%3A%2F%2Fexample.org` becomes `http://example.com?q=http://example.org`. If the webserver is not configured to treat these two urls the same the fetch will fail.

Note that it is impossible to test for this edge case with webmock since it parses urls with `Addressable::URI`.