### PR TITLE
Ruby 2.7 deprecated URI.unescape

### DIFF
--- a/lib/dragonfly/utils.rb
+++ b/lib/dragonfly/utils.rb
@@ -38,7 +38,7 @@ module Dragonfly
     end
 
     def uri_unescape(string)
-      URI.unescape(string)
+      URI::DEFAULT_PARSER.unescape(string)
     end
 
   end


### PR DESCRIPTION
URI.unescape (alias of URI.decode), has been deprecated. We need to update the implementation of that method.