### PR TITLE
Replace after_destroy by after_commit on: :destroy

### DIFF
--- a/lib/dragonfly/model/class_methods.rb
+++ b/lib/dragonfly/model/class_methods.rb
@@ -30,7 +30,12 @@ module Dragonfly
 
         # Add callbacks
         before_save :save_dragonfly_attachments if respond_to?(:before_save)
-        after_destroy :destroy_dragonfly_attachments if respond_to?(:after_destroy)
+        case
+        when respond_to?(:after_commit)
+          after_commit :destroy_dragonfly_attachments, on: :destroy
+        when respond_to?(:after_destroy)
+          after_destroy :destroy_dragonfly_attachments
+        end
 
         # Register the new attribute
         dragonfly_attachment_classes << new_dragonfly_attachment_class(attribute, app, config_block)


### PR DESCRIPTION
As wrongly stated at #477 changing `destroy_dragonfly_attachments` callback from `before_destroy` to `after_destroy` is **not** related with transaction/commit. It was failing cause foreign key's constraint. It still doesn't work as expected on rollback and it deletes dragonfly attachment from store:

```
class Foo < ApplicationRecord
  dragonfly_accessor :bar
end

f = Foo.create(bar: File.new('some.blob'))
Foo.transation do
  f.destroy
  raise ActiveRecord::Rollback
end
```

The right callback is `after_destroy_commit` or a more general Rails callback `after_commit on: :destroy`.

This PR is very conservative. It tries to attach `after_commit` and fallback to `after_destroy`, so it should still work even if ORMs doesn't have `after_commit`.