### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   global:
     - SKIP_FLAKY_TESTS: true
 
+cache: bundler
+
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y ghostscript


### PR DESCRIPTION
Would be interested to know why bundler caching of Travis hasn't been enabled in this repository. Thank you.