### PR TITLE
Allow flatten with encode

### DIFF
--- a/lib/dragonfly/image_magick/processors/encode.rb
+++ b/lib/dragonfly/image_magick/processors/encode.rb
@@ -6,7 +6,7 @@ module Dragonfly
       class Encode
         include ParamValidators
 
-        WHITELISTED_ARGS = %w(quality)
+        WHITELISTED_ARGS = %w(quality flatten)
 
         IS_IN_WHITELISTED_ARGS = ->(args_string) {
           args_string.scan(/-\w+/).all? { |arg|

--- a/spec/dragonfly/image_magick/processors/encode_spec.rb
+++ b/spec/dragonfly/image_magick/processors/encode_spec.rb
@@ -21,6 +21,10 @@ describe Dragonfly::ImageMagick::Processors::Encode do
       processor.call(image, "jpeg", "-quality 10")
     end
 
+    it "allows flatten arg" do
+      processor.call(image, "jpeg", "-quality 10 -flatten")
+    end
+
     it "disallows bad args" do
       expect {
         processor.call(image, "jpeg", "-write bad.png")


### PR DESCRIPTION
Flatten (reducing an animated GIF) should be allowed during encoding images in other formats.