### PR TITLE
Fix for edgecase with magic attributes

### DIFF
--- a/lib/dragonfly/model/attachment_class_methods.rb
+++ b/lib/dragonfly/model/attachment_class_methods.rb
@@ -98,8 +98,8 @@ module Dragonfly
           @magic_attributes ||= begin
             prefix = attribute.to_s + '_'
             model_class.public_instance_methods.inject([]) do |attrs, name|
-              _, __, suffix  = name.to_s.partition(prefix)
-              if !suffix.empty? && allowed_magic_attributes.include?(suffix.to_sym)
+              pre_prefix, __, suffix  = name.to_s.partition(prefix)
+              if !suffix.empty? && pre_prefix.empty? && allowed_magic_attributes.include?(suffix.to_sym)
                 attrs << suffix.to_sym
               end
               attrs

--- a/spec/dragonfly/model/model_spec.rb
+++ b/spec/dragonfly/model/model_spec.rb
@@ -399,6 +399,10 @@ describe "models" do
         ) do
         dragonfly_accessor :preview_image
         dragonfly_accessor :other_image
+
+        def method_about_other_image_size
+          fail "This should not be called"
+        end
       end
       @item = @item_class.new
     end


### PR DESCRIPTION
If you had a dragonfly accessor such as `photo` (with the associated `photo_uid` column)
but did not have a `photo_size` column, if you defined a method such as `thumbnail_photo_size`
it would include `:size` in the `magic_attributes` accessor for that model - even though one didn't
actually exist.

Ex:

```ruby
class User
  dragonfly_accessor :photo

  def thumbnail_photo_size
    # The inclusion of this method causes Dragonfly to think this class has a photo_size column
  end
end
```