### PR TITLE
Add expect before destroy on rspec

### DIFF
--- a/spec/dragonfly/model/active_record_spec.rb
+++ b/spec/dragonfly/model/active_record_spec.rb
@@ -52,6 +52,7 @@ unless RUBY_PLATFORM == "java"
 
       it "should remove the attachment as per usual otherwise" do
         uid = @photo.image_uid
+        expect(data_exists(uid)).to eq(true)
         @photo.destroy
         photo = Photo.last
         expect(photo).to be_nil

--- a/spec/dragonfly/model/active_record_spec.rb
+++ b/spec/dragonfly/model/active_record_spec.rb
@@ -52,11 +52,20 @@ unless RUBY_PLATFORM == "java"
 
       it "should remove the attachment as per usual otherwise" do
         uid = @photo.image_uid
-        expect(data_exists(uid)).to eq(true)
         @photo.destroy
         photo = Photo.last
         expect(photo).to be_nil
         expect(data_exists(uid)).to eq(false)
+      end
+
+      it "changes data store" do
+        uid = @photo.image_uid
+
+        expect {
+          @photo.destroy
+        }.to change {
+          data_exists(uid)
+        }.from(true).to(false)
       end
     end
   end


### PR DESCRIPTION
"ActiveRecord models destroying should remove the attachment as per usual otherwise" is a false green test. It will always pass since the store doesn't have any content before `@photo.destroy`. The `expect` added show this flaw. After this merge our suite test is going to be red as it should be.

<img width="1129" alt="Screen Shot 2021-07-20 at 15 49 07" src="https://user-images.githubusercontent.com/27499/126379074-52bd3737-0310-4263-8f05-481d58c4b240.png">
