### PR TITLE
Use is_color validator in plain generator

### DIFF
--- a/lib/dragonfly/image_magick/generators/plain.rb
+++ b/lib/dragonfly/image_magick/generators/plain.rb
@@ -9,7 +9,8 @@ module Dragonfly
 
         def call(content, width, height, opts = {})
           validate_all!([width, height], &is_number)
-          validate_all_keys!(opts, %w(colour color format), &is_word)
+          validate!(opts["format"], &is_word)
+          validate_all_keys!(opts, %w(colour color), &is_colour)
           format = extract_format(opts)
 
           colour = opts["colour"] || opts["color"] || "white"

--- a/lib/dragonfly/image_magick/generators/text.rb
+++ b/lib/dragonfly/image_magick/generators/text.rb
@@ -42,17 +42,13 @@ module Dragonfly
           "900" => 900,
         }
 
-        IS_COLOUR = ->(param) {
-          /\A(#\w+|rgba?\([\d\.,]+\)|\w+)\z/ === param
-        }
-
         def update_url(url_attributes, string, opts = {})
           url_attributes.name = "text.#{extract_format(opts)}"
         end
 
         def call(content, string, opts = {})
           validate_all_keys!(opts, %w(font font_family), &is_words)
-          validate_all_keys!(opts, %w(color background_color stroke_color), &IS_COLOUR)
+          validate_all_keys!(opts, %w(color background_color stroke_color), &is_colour)
           validate!(opts["format"], &is_word)
 
           opts = HashWithCssStyleKeys[opts]

--- a/lib/dragonfly/param_validators.rb
+++ b/lib/dragonfly/param_validators.rb
@@ -8,6 +8,10 @@ module Dragonfly
       param.is_a?(Numeric) || /\A[\d\.]+\z/ === param
     }
 
+    IS_COLOUR = ->(param) {
+      /\A(#\w+|rgba?\([\d\.,]+\)|\w+)\z/ === param
+    }
+
     IS_WORD = ->(param) {
       /\A\w+\z/ === param
     }
@@ -17,8 +21,11 @@ module Dragonfly
     }
 
     def is_number; IS_NUMBER; end
+    def is_colour; IS_COLOUR; end
     def is_word; IS_WORD; end
     def is_words; IS_WORDS; end
+
+    alias is_color is_colour
 
     def validate!(parameter, &validator)
       return if parameter.nil?

--- a/spec/dragonfly/image_magick/generators/plain_spec.rb
+++ b/spec/dragonfly/image_magick/generators/plain_spec.rb
@@ -33,6 +33,10 @@ describe Dragonfly::ImageMagick::Generators::Plain do
       generator.call(image, 1, 1, "color" => "red")
     end
 
+    it "works with Hex colors" do
+      generator.call(image, 1, 1, "color" => "#FF0000")
+    end
+
     it "blows up with a bad colour" do
       expect {
         generator.call(image, 1, 1, "colour" => "lardoin")

--- a/spec/dragonfly/image_magick/generators/text_spec.rb
+++ b/spec/dragonfly/image_magick/generators/text_spec.rb
@@ -90,19 +90,5 @@ describe Dragonfly::ImageMagick::Generators::Text do
         }.to raise_error(Dragonfly::ParamValidators::InvalidParameter)
       end
     end
-
-    ["rgb(33,33,33)", "rgba(33,33,33,0.5)", "rgb(33.5,33.5,33.5)", "#fff", "#efefef", "blue"].each do |colour|
-      it "allows #{colour.inspect} as a colour specification" do
-        generator.call(image, "mmm", "color" => colour)
-      end
-    end
-
-    ["rgb(33, 33, 33)", "something else", "blue:", "f#ff"].each do |colour|
-      it "disallows #{colour.inspect} as a colour specification" do
-        expect {
-          generator.call(image, "mmm", "color" => colour)
-        }.to raise_error(Dragonfly::ParamValidators::InvalidParameter)
-      end
-    end
   end
 end

--- a/spec/dragonfly/param_validators_spec.rb
+++ b/spec/dragonfly/param_validators_spec.rb
@@ -71,6 +71,22 @@ describe Dragonfly::ParamValidators do
     end
   end
 
+  describe "is_colour" do
+    ["rgb(33,33,33)", "rgba(33,33,33,0.5)", "rgb(33.5,33.5,33.5)", "#fff", "#efefef", "blue"].each do |val|
+      it "validates #{val.inspect}" do
+        validate!(val, &is_colour)
+      end
+    end
+
+    ["rgb(33, 33, 33)", "something else", "blue:", "f#ff"].each do |val|
+      it "validates #{val.inspect}" do
+        expect {
+          validate!(val, &is_colour)
+        }.to raise_error(Dragonfly::ParamValidators::InvalidParameter)
+      end
+    end
+  end
+
   describe "is_words" do
     ["hello there", "Hi", "  What is Up "].each do |val|
       it "validates #{val.inspect}" do


### PR DESCRIPTION
This moves the `IS_COLOUR` validation out of the text generator and into the ParamValidators module so we can use it in the plain generator as well.

Prior to this, specifying a color in hex format in the plain generator would raise a `Dragonfly::ParamValidators::InvalidParameter` exception.

Fixes #519 (and maybe #518 too)