### PR TITLE
Fix size detection for "soft-rotated" JPEGs

### DIFF
--- a/lib/dragonfly/image_magick/analysers/image_properties.rb
+++ b/lib/dragonfly/image_magick/analysers/image_properties.rb
@@ -6,7 +6,7 @@ module Dragonfly
         def call(content)
           identify_command = content.env[:identify_command] || 'identify'
           details = content.shell_eval do |path|
-            "#{identify_command} -ping -format '%m %w %h' #{path}"
+            "#{identify_command} +ping -auto-orient -format '%m %w %h' #{path}"
           end
           format, width, height = details.split
           {

--- a/lib/dragonfly/image_magick/commands.rb
+++ b/lib/dragonfly/image_magick/commands.rb
@@ -12,7 +12,7 @@ module Dragonfly
         frame_string = "[#{opts["frame"]}]" if opts["frame"]
 
         content.shell_update :ext => format do |old_path, new_path|
-          "#{convert_command} #{input_args} #{delegate_string}#{old_path}#{frame_string} #{args} #{new_path}"
+          "#{convert_command} -auto-orient #{input_args} #{delegate_string}#{old_path}#{frame_string} #{args} #{new_path}"
         end
 
         if format


### PR DESCRIPTION
For JPEGs that are rotated 90° or 270° via EXIF flag, the detected width and height were swapped. This patch fixes it.